### PR TITLE
Add cmi5 runtime support to the SCORM component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -376,11 +376,24 @@ function sendBridgeEvent(eventName, payload) {
   PandaBridge.send(eventName, payload);
 }
 
+function getLocalStorageKeyPrefix(unitId) {
+  if (
+    runtimeSelection.protocol === 'cmi5'
+    && runtimeSelection.context.cmi5
+    && unitId
+  ) {
+    return `${unitId}:cmi5:${runtimeSelection.context.cmi5.registration}`;
+  }
+
+  return unitId;
+}
+
 function createRuntimeTracker() {
   const runtimeLogger = getRuntimeLogger();
   const storage = getBrowserStorage();
   const isLocalStorage = !!(properties && properties.isLocalStorage);
   const unitId = properties && properties[PandaBridge.UNIQUE_ID];
+  const localStorageKeyPrefix = getLocalStorageKeyPrefix(unitId);
   const companionAdapters = [];
   let adapter = null;
 
@@ -404,6 +417,7 @@ function createRuntimeTracker() {
     adapter = createLocalAdapter({
       enabled: isLocalStorage,
       unitId,
+      storageKeyPrefix: localStorageKeyPrefix,
       storage,
       send: sendBridgeEvent,
     });
@@ -413,6 +427,7 @@ function createRuntimeTracker() {
     companionAdapters.push(createLocalAdapter({
       enabled: true,
       unitId,
+      storageKeyPrefix: localStorageKeyPrefix,
       storage,
       send: sendBridgeEvent,
     }));

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,20 @@ import {
   DEBUG_STORAGE_KEY,
   isDebugLoggingEnabled,
 } from './logging';
+import { selectProtocol } from './runtime/select-protocol';
 
 let properties = null;
 
 let API_2004 = null;
 let API_11_12 = null;
+let runtimeSelection = {
+  protocol: 'local',
+  context: {
+    cmi5: null,
+    hasScorm2004: false,
+    hasScorm12: false,
+  },
+};
 
 let startTime = null;
 let currentScore = 0;
@@ -41,6 +50,7 @@ const logger = createLogger({
 });
 
 let lastApiStateSignature = null;
+let lastRuntimeSelectionSignature = null;
 
 function logDebug(message, details) {
   logger.debug(message, details);
@@ -59,12 +69,20 @@ function logError(message, details) {
 }
 
 function getActiveProtocol() {
-  if (API_11_12) {
+  if (runtimeSelection.protocol === 'cmi5') {
+    return 'CMI5';
+  }
+
+  if (runtimeSelection.protocol === 'scorm2004' || API_2004) {
+    return 'SCORM 2004';
+  }
+
+  if (runtimeSelection.protocol === 'scorm12' || API_11_12) {
     return 'SCORM 1.2';
   }
 
-  if (API_2004) {
-    return 'SCORM 2004';
+  if (runtimeSelection.protocol === 'local') {
+    return 'Local';
   }
 
   return null;
@@ -144,6 +162,10 @@ function logApiState() {
   lastApiStateSignature = signature;
 
   if (signature === 'missing') {
+    if (runtimeSelection.protocol === 'cmi5') {
+      return;
+    }
+
     logError('No SCORM API available after discovery', {
       currentWindow: getWindowDebugInfo(window, 'ensureScormAPI'),
       referrer: document.referrer,
@@ -158,6 +180,28 @@ function logApiState() {
     protocol: getActiveProtocol(),
     scorm12: !!API_11_12,
     scorm2004: !!API_2004,
+  });
+}
+
+function logRuntimeSelection() {
+  const signature = [
+    runtimeSelection.protocol,
+    runtimeSelection.context.hasScorm2004,
+    runtimeSelection.context.hasScorm12,
+    runtimeSelection.context.cmi5 != null,
+  ].join(':');
+
+  if (signature === lastRuntimeSelectionSignature) {
+    return;
+  }
+
+  lastRuntimeSelectionSignature = signature;
+
+  logInfo('Protocol selected', {
+    protocol: getActiveProtocol(),
+    hasScorm2004: runtimeSelection.context.hasScorm2004,
+    hasScorm12: runtimeSelection.context.hasScorm12,
+    hasCmi5LaunchContext: runtimeSelection.context.cmi5 != null,
   });
 }
 
@@ -419,6 +463,12 @@ function millisecondsToTime2004(seconds) {
 function discoverScormAPI() {
   API_2004 = discoverScormAPI2004();
   API_11_12 = discoverScormAPI1112();
+  runtimeSelection = selectProtocol({
+    queryString: window.location && window.location.search,
+    hasScorm2004: !!API_2004,
+    hasScorm12: !!API_11_12,
+  });
+  logRuntimeSelection();
   logApiState();
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   isDebugLoggingEnabled,
 } from './logging';
 import { createLocalAdapter } from './runtime/adapters/local';
+import { createCmi5Adapter } from './runtime/adapters/cmi5';
 import { createScorm12Adapter } from './runtime/adapters/scorm12';
 import { createScorm2004Adapter } from './runtime/adapters/scorm2004';
 import { selectProtocol } from './runtime/select-protocol';
@@ -388,6 +389,12 @@ function createRuntimeTracker() {
       api: API_2004,
       logger: runtimeLogger,
     });
+  } else if (runtimeSelection.protocol === 'cmi5' && runtimeSelection.context.cmi5) {
+    adapter = createCmi5Adapter({
+      launchContext: runtimeSelection.context.cmi5,
+      fetchFn: (...args) => window.fetch(...args),
+      logger: runtimeLogger,
+    });
   } else if (runtimeSelection.protocol === 'scorm12' && API_11_12) {
     adapter = createScorm12Adapter({
       api: API_11_12,
@@ -402,7 +409,7 @@ function createRuntimeTracker() {
     });
   }
 
-  if (adapter == null && isLocalStorage) {
+  if (runtimeSelection.protocol !== 'local' && isLocalStorage) {
     companionAdapters.push(createLocalAdapter({
       enabled: true,
       unitId,
@@ -419,7 +426,20 @@ function createRuntimeTracker() {
   });
 }
 
+function refreshRuntimeTracker() {
+  const currentState = tracker ? tracker.getState() : null;
+
+  if (currentState && (currentState.sessionStarted || currentState.sessionFinished)) {
+    return;
+  }
+
+  ensureScormAPI();
+  tracker = createRuntimeTracker();
+}
+
 function getTracker(actionName) {
+  refreshRuntimeTracker();
+
   if (tracker) {
     return tracker;
   }
@@ -431,6 +451,17 @@ function getTracker(actionName) {
   return null;
 }
 
+function runTrackerAction(actionName, handler) {
+  const activeTracker = getTracker(actionName);
+  if (!activeTracker) {
+    return;
+  }
+
+  Promise.resolve(handler(activeTracker)).catch((error) => {
+    logError(`Unexpected error during "${actionName}"`, formatError(error));
+  });
+}
+
 PandaBridge.init(() => {
   PandaBridge.onLoad((pandaData) => {
     properties = pandaData.properties;
@@ -440,62 +471,38 @@ PandaBridge.init(() => {
   });
 
   PandaBridge.listen('start', () => {
-    const activeTracker = getTracker('start');
-    if (activeTracker) {
-      activeTracker.start();
-    }
+    runTrackerAction('start', (activeTracker) => activeTracker.start());
   });
 
   PandaBridge.listen('incomplete', () => {
-    const activeTracker = getTracker('incomplete');
-    if (activeTracker) {
-      activeTracker.incomplete();
-    }
+    runTrackerAction('incomplete', (activeTracker) => activeTracker.incomplete());
   });
 
   PandaBridge.listen('complete', () => {
-    const activeTracker = getTracker('complete');
-    if (activeTracker) {
-      activeTracker.complete();
-    }
+    runTrackerAction('complete', (activeTracker) => activeTracker.complete());
   });
 
   PandaBridge.listen('timedout', () => {
-    const activeTracker = getTracker('timedout');
-    if (activeTracker) {
-      activeTracker.timedout();
-    }
+    runTrackerAction('timedout', (activeTracker) => activeTracker.timedout());
   });
 
   PandaBridge.listen('progress', (args) => {
     const props = args[0] || {};
-    const activeTracker = getTracker('progress');
-    if (activeTracker) {
-      activeTracker.progress(parseFloat(props.value || 0));
-    }
+    runTrackerAction('progress', (activeTracker) => activeTracker.progress(parseFloat(props.value || 0)));
   });
 
   PandaBridge.listen('score', (args) => {
     const props = args[0] || {};
-    const activeTracker = getTracker('score');
-    if (activeTracker) {
-      activeTracker.score(parseInt(props.value || 0));
-    }
+    runTrackerAction('score', (activeTracker) => activeTracker.score(parseInt(props.value || 0)));
   });
 
   PandaBridge.listen('incScore', (args) => {
     const props = args[0] || {};
-    const activeTracker = getTracker('incScore');
-    if (activeTracker) {
-      activeTracker.incScore(parseInt(props.value || 0));
-    }
+    runTrackerAction('incScore', (activeTracker) => activeTracker.incScore(parseInt(props.value || 0)));
   });
 
   PandaBridge.listen('decScore', (args) => {
     const props = args[0] || {};
-    const activeTracker = getTracker('decScore');
-    if (activeTracker) {
-      activeTracker.decScore(parseInt(props.value || 0));
-    }
+    runTrackerAction('decScore', (activeTracker) => activeTracker.decScore(parseInt(props.value || 0)));
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,11 @@ import {
   DEBUG_STORAGE_KEY,
   isDebugLoggingEnabled,
 } from './logging';
+import { createLocalAdapter } from './runtime/adapters/local';
+import { createScorm12Adapter } from './runtime/adapters/scorm12';
+import { createScorm2004Adapter } from './runtime/adapters/scorm2004';
 import { selectProtocol } from './runtime/select-protocol';
+import { createTracker } from './runtime/tracker-core';
 
 let properties = null;
 
@@ -20,11 +24,7 @@ let runtimeSelection = {
     hasScorm12: false,
   },
 };
-
-let startTime = null;
-let currentScore = 0;
-let sessionStarted = false;
-let sessionFinished = false;
+let tracker = null;
 
 const SCORE_MIN_KEY = 'score.min';
 const SCORE_MAX_KEY = 'score.max';
@@ -98,15 +98,6 @@ function getComponentConfigSummary() {
   };
 }
 
-function getSessionState() {
-  return {
-    protocol: getActiveProtocol(),
-    sessionStarted,
-    sessionFinished,
-    startTime,
-  };
-}
-
 function formatError(error) {
   if (!error) {
     return null;
@@ -162,7 +153,7 @@ function logApiState() {
   lastApiStateSignature = signature;
 
   if (signature === 'missing') {
-    if (runtimeSelection.protocol === 'cmi5') {
+    if (runtimeSelection.protocol === 'cmi5' || runtimeSelection.protocol === 'local') {
       return;
     }
 
@@ -203,85 +194,6 @@ function logRuntimeSelection() {
     hasScorm12: runtimeSelection.context.hasScorm12,
     hasCmi5LaunchContext: runtimeSelection.context.cmi5 != null,
   });
-}
-
-function getScorm12ErrorDetails() {
-  if (!API_11_12 || !API_11_12.LMSGetLastError) {
-    return null;
-  }
-
-  const code = API_11_12.LMSGetLastError();
-  return {
-    code,
-    errorString: API_11_12.LMSGetErrorString ? API_11_12.LMSGetErrorString(code) : null,
-    diagnostic: API_11_12.LMSGetDiagnostic ? API_11_12.LMSGetDiagnostic(code) : null,
-  };
-}
-
-function getScorm2004ErrorDetails() {
-  if (!API_2004 || !API_2004.GetLastError) {
-    return null;
-  }
-
-  const code = API_2004.GetLastError();
-  return {
-    code,
-    errorString: API_2004.GetErrorString ? API_2004.GetErrorString(code) : null,
-    diagnostic: API_2004.GetDiagnostic ? API_2004.GetDiagnostic(code) : null,
-  };
-}
-
-function isScormCallFailure(result, errorDetails) {
-  if (result === false || result === 'false') {
-    return true;
-  }
-
-  if (!errorDetails || errorDetails.code == null) {
-    return false;
-  }
-
-  return `${errorDetails.code}` !== '0';
-}
-
-function isSuccessfulScormResult(result) {
-  return result === true || result === 'true';
-}
-
-function logScormCall(protocol, method, args, result, errorDetails) {
-  const payload = {
-    protocol,
-    method,
-    args,
-    result,
-    error: errorDetails,
-  };
-
-  if (isScormCallFailure(result, errorDetails)) {
-    logError('SCORM call failed', payload);
-    return;
-  }
-
-  logDebug('SCORM call', payload);
-}
-
-function callScorm12(method, ...args) {
-  if (!API_11_12 || typeof API_11_12[method] !== 'function') {
-    return null;
-  }
-
-  const result = API_11_12[method](...args);
-  logScormCall('SCORM 1.2', method, args, result, getScorm12ErrorDetails());
-  return result;
-}
-
-function callScorm2004(method, ...args) {
-  if (!API_2004 || typeof API_2004[method] !== 'function') {
-    return null;
-  }
-
-  const result = API_2004[method](...args);
-  logScormCall('SCORM 2004', method, args, result, getScorm2004ErrorDetails());
-  return result;
 }
 
 /* API 2004 discover functions */
@@ -416,50 +328,6 @@ function discoverScormAPI1112() {
   return api1112;
 }
 
-/* SCORM utils */
-
-function millisecondsToTime(seconds) {
-  seconds = Math.round(seconds / 1000);
-
-  let s = seconds % 60;
-  seconds -= s;
-  if (s < 10) {
-    s = `0${s}`;
-  }
-
-  let m = (seconds / 60) % 60;
-  if (m < 10) {
-    m = `0${m}`;
-  }
-
-  let h = Math.floor(seconds / 3600);
-  if (h < 10) {
-    h = `0${h}`;
-  }
-  return `${h}:${m}:${s}`;
-}
-
-function millisecondsToTime2004(seconds) {
-  seconds = Math.round(seconds / 1000);
-
-  let s = seconds % 60;
-  seconds -= s;
-  if (s < 10) {
-    s = `0${s}`;
-  }
-
-  let m = (seconds / 60) % 60;
-  if (m < 10) {
-    m = `0${m}`;
-  }
-
-  let h = Math.floor(seconds / 3600);
-  if (h < 10) {
-    h = `0${h}`;
-  }
-  return `PT${h}H${m}M${s}S`;
-}
-
 function discoverScormAPI() {
   API_2004 = discoverScormAPI2004();
   API_11_12 = discoverScormAPI1112();
@@ -486,252 +354,81 @@ function ensureScormAPI() {
   return API_2004 != null || API_11_12 != null;
 }
 
-function ensureSessionStarted(actionName) {
-  ensureScormAPI();
-
-  if (sessionFinished) {
-    logWarn(`Ignoring "${actionName}" because the session is already finished`, getSessionState());
-    return false;
-  }
-
-  if (!sessionStarted || startTime == null) {
-    logWarn(`Ignoring "${actionName}" because the session has not been started yet`, getSessionState());
-    return false;
-  }
-
-  return true;
-}
-
-function setScormProgress(progress) {
-  const {
-    isLocalStorage,
-    [PandaBridge.UNIQUE_ID]: unitId,
-  } = properties;
-  const progressBookmark = `${Math.round(progress * 100)}`;
-
-  const tt = (new Date()).getTime() - startTime;
-
-  if (API_11_12 && API_11_12.LMSSetValue) {
-    callScorm12('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(tt));
-    const locationResult = callScorm12('LMSSetValue', 'cmi.core.lesson_location', progressBookmark);
-    const commitResult = callScorm12('LMSCommit', '');
-    const details = {
-      protocol: 'SCORM 1.2',
-      progress,
-      progressBookmark,
-      target: 'cmi.core.lesson_location',
-      elapsedMs: tt,
-    };
-
-    if (isSuccessfulScormResult(locationResult) && isSuccessfulScormResult(commitResult)) {
-      logInfo('Progress synced', details);
-    } else {
-      logWarn('Progress update completed with SCORM warnings', details);
-    }
-  }
-  if (API_2004 && API_2004.Terminate) {
-    const timefull = millisecondsToTime2004(tt);
-    callScorm2004('SetValue', 'cmi.session_time', timefull);
-    const progressResult = callScorm2004('SetValue', 'cmi.progress_measure', progress);
-    const commitResult = callScorm2004('Commit', '');
-    const details = {
-      protocol: 'SCORM 2004',
-      progress,
-      target: 'cmi.progress_measure',
-      elapsedMs: tt,
-    };
-
-    if (isSuccessfulScormResult(progressResult) && isSuccessfulScormResult(commitResult)) {
-      logInfo('Progress synced', details);
-    } else {
-      logWarn('Progress update completed with SCORM warnings', details);
-    }
-  }
-  if (isLocalStorage) {
-    localStorage.setItem(`${unitId}_total_time`, tt);
-    localStorage.setItem(`${unitId}_progress`, progress);
-    PandaBridge.send('synchronize', [progress, 'syncProgress', true]);
+function getBrowserStorage() {
+  try {
+    return window.localStorage;
+  } catch (error) {
+    return null;
   }
 }
 
-function setScormScore(score) {
-  const {
-    isLocalStorage,
-    [PandaBridge.UNIQUE_ID]: unitId,
-    [SCORE_MIN_KEY]: scoreMin,
-    [SCORE_MAX_KEY]: scoreMax,
-  } = properties;
-
-  const tt = (new Date()).getTime() - startTime;
-
-  if (API_11_12 && API_11_12.LMSSetValue) {
-    callScorm12('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(tt));
-    const scoreResult = callScorm12('LMSSetValue', 'cmi.core.score.raw', score);
-    const commitResult = callScorm12('LMSCommit', '');
-    const details = {
-      protocol: 'SCORM 1.2',
-      score,
-      scoreMin,
-      scoreMax,
-      target: 'cmi.core.score.raw',
-      elapsedMs: tt,
-    };
-
-    if (isSuccessfulScormResult(scoreResult) && isSuccessfulScormResult(commitResult)) {
-      logInfo('Score synced', details);
-    } else {
-      logWarn('Score update completed with SCORM warnings', details);
-    }
-  }
-  if (API_2004 && API_2004.Terminate) {
-    const timefull = millisecondsToTime2004(tt);
-    callScorm2004('SetValue', 'cmi.session_time', timefull);
-    const scoreRawResult = callScorm2004('SetValue', 'cmi.score.raw', score);
-    const scoreScaledResult = callScorm2004('SetValue', 'cmi.score.scaled', score / parseInt(scoreMax));
-    const commitResult = callScorm2004('Commit', '');
-    const details = {
-      protocol: 'SCORM 2004',
-      score,
-      scoreMin,
-      scoreMax,
-      targets: ['cmi.score.raw', 'cmi.score.scaled'],
-      elapsedMs: tt,
-    };
-
-    if (
-      isSuccessfulScormResult(scoreRawResult)
-      && isSuccessfulScormResult(scoreScaledResult)
-      && isSuccessfulScormResult(commitResult)
-    ) {
-      logInfo('Score synced', details);
-    } else {
-      logWarn('Score update completed with SCORM warnings', details);
-    }
-  }
-  if (isLocalStorage) {
-    localStorage.setItem(`${unitId}_total_time`, tt);
-    localStorage.setItem(`${unitId}_score`, score);
-    PandaBridge.send('synchronize', [
-      (score * 100) / (scoreMax - scoreMin),
-      'syncScore',
-      true,
-    ]);
-  }
-}
-
-function reloadState() {
-  const {
-    isLocalStorage,
-    [PandaBridge.UNIQUE_ID]: unitId,
-  } = properties;
-  let restoredProgress = null;
-  let restoredScore = null;
-
-  if (isLocalStorage) {
-    const progress = localStorage.getItem(`${unitId}_progress`);
-    if (progress != null) {
-      restoredProgress = parseFloat(progress);
-      logDebug('Restoring progress from localStorage', { restoredProgress });
-    }
-    const score = localStorage.getItem(`${unitId}_score`);
-    if (score != null) {
-      currentScore = parseFloat(score);
-      restoredScore = currentScore;
-      logDebug('Restoring score from localStorage', { restoredScore });
-    }
-    const tt = localStorage.getItem(`${unitId}_total_time`);
-    if (tt != null) {
-      startTime = (new Date()).getTime() - parseInt(tt);
-    }
-  }
-  if (startTime == null) {
-    startTime = (new Date()).getTime();
-  }
-
+function getRuntimeLogger() {
   return {
-    restoredProgress,
-    restoredScore,
+    debug: logDebug,
+    info: logInfo,
+    warn: logWarn,
+    error: logError,
   };
 }
 
-function startSession() {
-  const {
-    [SCORE_MIN_KEY]: scoreMin,
-    [SCORE_MAX_KEY]: scoreMax,
-  } = properties || {};
+function sendBridgeEvent(eventName, payload) {
+  PandaBridge.send(eventName, payload);
+}
 
-  if (!ensureScormAPI()) {
-    logError('No SCORM API found, cannot start session');
-    return false;
-  }
+function createRuntimeTracker() {
+  const runtimeLogger = getRuntimeLogger();
+  const storage = getBrowserStorage();
+  const isLocalStorage = !!(properties && properties.isLocalStorage);
+  const unitId = properties && properties[PandaBridge.UNIQUE_ID];
+  const companionAdapters = [];
+  let adapter = null;
 
-  if (sessionFinished) {
-    logWarn('Ignoring start because the session is already finished', getSessionState());
-    return false;
-  }
-
-  if (sessionStarted) {
-    logWarn('Ignoring start because the session is already started', getSessionState());
-    return true;
-  }
-
-  const {
-    restoredProgress,
-    restoredScore,
-  } = reloadState();
-
-  let didStart = false;
-  if (API_11_12 && API_11_12.LMSInitialize) {
-    const initResult = callScorm12('LMSInitialize', '');
-    if (initResult === 'true') {
-      didStart = true;
-      callScorm12('LMSSetValue', 'cmi.core.lesson_status', 'incomplete');
-      callScorm12('LMSSetValue', 'cmi.core.score.min', scoreMin);
-      callScorm12('LMSSetValue', 'cmi.core.score.max', scoreMax);
-      callScorm12('LMSCommit', '');
-    }
-  }
-  if (API_2004 && API_2004.Initialize) {
-    const initResult = callScorm2004('Initialize', '');
-    if (initResult === 'true') {
-      didStart = true;
-      callScorm2004('SetValue', 'cmi.score.min', scoreMin);
-      callScorm2004('SetValue', 'cmi.score.max', scoreMax);
-      callScorm2004('Commit', '');
-    }
-  }
-
-  sessionStarted = didStart;
-  sessionFinished = false;
-
-  if (sessionStarted) {
-    if (restoredProgress != null) {
-      setScormProgress(restoredProgress);
-    }
-    if (restoredScore != null) {
-      setScormScore(restoredScore);
-    }
-  }
-
-  if (!didStart) {
-    logError('Session start failed', {
-      protocol: getActiveProtocol(),
-      scoreMin,
-      scoreMax,
+  if (runtimeSelection.protocol === 'scorm2004' && API_2004) {
+    adapter = createScorm2004Adapter({
+      api: API_2004,
+      logger: runtimeLogger,
     });
-    return didStart;
+  } else if (runtimeSelection.protocol === 'scorm12' && API_11_12) {
+    adapter = createScorm12Adapter({
+      api: API_11_12,
+      logger: runtimeLogger,
+    });
+  } else if (runtimeSelection.protocol === 'local') {
+    adapter = createLocalAdapter({
+      enabled: isLocalStorage,
+      unitId,
+      storage,
+      send: sendBridgeEvent,
+    });
   }
 
-  logInfo('Session started', {
-    protocol: getActiveProtocol(),
-    scoreMin,
-    scoreMax,
-    startTime,
-    restoredProgress,
-    restoredScore,
-  });
+  if (adapter == null && isLocalStorage) {
+    companionAdapters.push(createLocalAdapter({
+      enabled: true,
+      unitId,
+      storage,
+      send: sendBridgeEvent,
+    }));
+  }
 
-  return didStart;
+  return createTracker({
+    adapter,
+    companionAdapters,
+    properties,
+    logger: runtimeLogger,
+  });
+}
+
+function getTracker(actionName) {
+  if (tracker) {
+    return tracker;
+  }
+
+  logWarn(`Ignoring "${actionName}" because the component is not ready yet`, {
+    loaded: properties != null,
+    protocol: getActiveProtocol(),
+  });
+  return null;
 }
 
 PandaBridge.init(() => {
@@ -739,196 +436,66 @@ PandaBridge.init(() => {
     properties = pandaData.properties;
     logInfo('Component loaded', getComponentConfigSummary());
     ensureScormAPI();
+    tracker = createRuntimeTracker();
   });
 
   PandaBridge.listen('start', () => {
-    startSession();
+    const activeTracker = getTracker('start');
+    if (activeTracker) {
+      activeTracker.start();
+    }
   });
 
   PandaBridge.listen('incomplete', () => {
-    const {
-      isLocalStorage,
-      [PandaBridge.UNIQUE_ID]: unitId,
-    } = properties;
-
-    if (!ensureSessionStarted('incomplete')) {
-      return;
-    }
-
-    const tt = (new Date()).getTime() - startTime;
-
-    if (API_11_12 && API_11_12.LMSSetValue) {
-      const statusResult = callScorm12('LMSSetValue', 'cmi.core.lesson_status', 'incomplete');
-      callScorm12('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(tt));
-      const commitResult = callScorm12('LMSCommit', '');
-
-      if (isSuccessfulScormResult(statusResult) && isSuccessfulScormResult(commitResult)) {
-        logInfo('Session marked incomplete', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      } else {
-        logWarn('Incomplete status update completed with SCORM warnings', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      }
-    }
-    if (API_2004 && API_2004.SetValue) {
-      const timefull = millisecondsToTime2004(tt);
-      const statusResult = callScorm2004('SetValue', 'cmi.completion_status', 'incomplete');
-      callScorm2004('SetValue', 'cmi.session_time', timefull);
-      const commitResult = callScorm2004('Commit', '');
-
-      if (isSuccessfulScormResult(statusResult) && isSuccessfulScormResult(commitResult)) {
-        logInfo('Session marked incomplete', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      } else {
-        logWarn('Incomplete status update completed with SCORM warnings', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      }
-    }
-    if (isLocalStorage) {
-      localStorage.setItem(`${unitId}_total_time`, tt);
+    const activeTracker = getTracker('incomplete');
+    if (activeTracker) {
+      activeTracker.incomplete();
     }
   });
 
   PandaBridge.listen('complete', () => {
-    const {
-      isLocalStorage,
-      [PandaBridge.UNIQUE_ID]: unitId,
-    } = properties;
-
-    if (!ensureSessionStarted('complete')) {
-      return;
+    const activeTracker = getTracker('complete');
+    if (activeTracker) {
+      activeTracker.complete();
     }
-
-    const tt = (new Date()).getTime() - startTime;
-
-    if (API_11_12 && API_11_12.LMSSetValue) {
-      callScorm12('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(tt));
-      const statusResult = callScorm12('LMSSetValue', 'cmi.core.lesson_status', 'completed');
-      const commitResult = callScorm12('LMSCommit', '');
-      const finishResult = callScorm12('LMSFinish', '');
-
-      if (
-        isSuccessfulScormResult(statusResult)
-        && isSuccessfulScormResult(commitResult)
-        && isSuccessfulScormResult(finishResult)
-      ) {
-        logInfo('Session completed', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      } else {
-        logWarn('Session completion completed with SCORM warnings', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      }
-    }
-    if (API_2004 && API_2004.Terminate) {
-      const timefull = millisecondsToTime2004(tt);
-      callScorm2004('SetValue', 'cmi.session_time', timefull);
-      const statusResult = callScorm2004('SetValue', 'cmi.completion_status', 'completed');
-      const commitResult = callScorm2004('Commit', '');
-      const terminateResult = callScorm2004('Terminate', '');
-
-      if (
-        isSuccessfulScormResult(statusResult)
-        && isSuccessfulScormResult(commitResult)
-        && isSuccessfulScormResult(terminateResult)
-      ) {
-        logInfo('Session completed', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      } else {
-        logWarn('Session completion completed with SCORM warnings', {
-          protocol: getActiveProtocol(),
-          elapsedMs: tt,
-        });
-      }
-    }
-    if (isLocalStorage) {
-      localStorage.setItem(`${unitId}_total_time`, tt);
-    }
-
-    sessionStarted = false;
-    sessionFinished = true;
   });
 
   PandaBridge.listen('timedout', () => {
-    if (!ensureSessionStarted('timedout')) {
-      return;
+    const activeTracker = getTracker('timedout');
+    if (activeTracker) {
+      activeTracker.timedout();
     }
-
-    if (API_11_12 && API_11_12.LMSSetValue) {
-      callScorm12('LMSSetValue', 'cmi.core.exit', 'time-out');
-      callScorm12('LMSCommit', '');
-      callScorm12('LMSFinish', '');
-    }
-    if (API_2004 && API_2004.Terminate) {
-      callScorm2004('SetValue', 'cmi.core.exit', 'time-out');
-      callScorm2004('SetValue', 'cmi.exit', 'time-out');
-      callScorm2004('Commit', '');
-      callScorm2004('Terminate', '');
-    }
-
-    sessionStarted = false;
-    sessionFinished = true;
-    logWarn('Session timed out', {
-      protocol: getActiveProtocol(),
-    });
   });
 
   PandaBridge.listen('progress', (args) => {
     const props = args[0] || {};
-    const progress = parseFloat(props.value || 0) / 100;
-
-    if (!ensureSessionStarted('progress')) {
-      return;
+    const activeTracker = getTracker('progress');
+    if (activeTracker) {
+      activeTracker.progress(parseFloat(props.value || 0));
     }
-
-    setScormProgress(progress);
   });
 
   PandaBridge.listen('score', (args) => {
     const props = args[0] || {};
-    currentScore = parseInt(props.value || 0);
-
-    if (!ensureSessionStarted('score')) {
-      return;
+    const activeTracker = getTracker('score');
+    if (activeTracker) {
+      activeTracker.score(parseInt(props.value || 0));
     }
-
-    setScormScore(currentScore);
   });
 
   PandaBridge.listen('incScore', (args) => {
     const props = args[0] || {};
-    const value = parseInt(props.value || 0);
-
-    if (!ensureSessionStarted('incScore')) {
-      return;
+    const activeTracker = getTracker('incScore');
+    if (activeTracker) {
+      activeTracker.incScore(parseInt(props.value || 0));
     }
-
-    currentScore += value;
-    setScormScore(currentScore);
   });
 
   PandaBridge.listen('decScore', (args) => {
     const props = args[0] || {};
-    const value = parseInt(props.value || 0);
-
-    if (!ensureSessionStarted('decScore')) {
-      return;
+    const activeTracker = getTracker('decScore');
+    if (activeTracker) {
+      activeTracker.decScore(parseInt(props.value || 0));
     }
-
-    currentScore -= value;
-    setScormScore(currentScore);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -429,7 +429,10 @@ function createRuntimeTracker() {
 function refreshRuntimeTracker() {
   const currentState = tracker ? tracker.getState() : null;
 
-  if (currentState && (currentState.sessionStarted || currentState.sessionFinished)) {
+  if (
+    currentState
+    && (currentState.sessionStarting || currentState.sessionStarted || currentState.sessionFinished)
+  ) {
     return;
   }
 

--- a/src/runtime/adapters/cmi5.mjs
+++ b/src/runtime/adapters/cmi5.mjs
@@ -4,7 +4,15 @@ const XAPI_VERSION = '1.0.3';
 const LAUNCH_DATA_STATE_ID = 'LMS.LaunchData';
 const LEARNER_PREFERENCES_PROFILE_ID = 'cmi5LearnerPreferences';
 const PROGRESS_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/result/extensions/progress';
-const MASTERY_SCORE_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/context/extensions/masteryscore';
+const CMI5_CATEGORY_ID = 'https://w3id.org/xapi/cmi5/context/categories/cmi5';
+const MOVEON_CATEGORY_ID = 'https://w3id.org/xapi/cmi5/context/categories/moveon';
+
+const MOVE_ON = {
+  Completed: 'Completed',
+  Passed: 'Passed',
+  CompletedAndPassed: 'CompletedAndPassed',
+  CompletedOrPassed: 'CompletedOrPassed',
+};
 
 const VERBS = {
   initialized: {
@@ -127,6 +135,30 @@ function createNoopLogger(logger = {}) {
   };
 }
 
+function ensureCategoryActivity(context, categoryId) {
+  if (!categoryId) {
+    return;
+  }
+
+  if (!context.contextActivities) {
+    context.contextActivities = {};
+  }
+
+  if (!Array.isArray(context.contextActivities.category)) {
+    context.contextActivities.category = [];
+  }
+
+  const hasCategory = context.contextActivities.category.some(
+    (activity) => activity && activity.id === categoryId,
+  );
+  if (!hasCategory) {
+    context.contextActivities.category.push({
+      objectType: 'Activity',
+      id: categoryId,
+    });
+  }
+}
+
 export function createCmi5Adapter({
   launchContext,
   fetchFn = (...args) => fetch(...args),
@@ -143,6 +175,7 @@ export function createCmi5Adapter({
   let initialized = false;
   let terminated = false;
   let latestScore = null;
+  let resolvedMoveOn = null;
 
   function getActorString() {
     if (typeof launchContext.actor === 'string' && launchContext.actor.length > 0) {
@@ -258,21 +291,44 @@ export function createCmi5Adapter({
     return bootPromise;
   }
 
+  function getMoveOn() {
+    if (resolvedMoveOn != null) {
+      return resolvedMoveOn;
+    }
+
+    switch (launchData && launchData.moveOn) {
+      case MOVE_ON.Passed:
+      case MOVE_ON.CompletedAndPassed:
+      case MOVE_ON.CompletedOrPassed:
+      case MOVE_ON.Completed:
+        resolvedMoveOn = launchData.moveOn;
+        break;
+      default:
+        runtimeLogger.warn('Unknown CMI5 moveOn, falling back to Completed', {
+          moveOn: launchData && launchData.moveOn,
+        });
+        resolvedMoveOn = MOVE_ON.Completed;
+        break;
+    }
+
+    return resolvedMoveOn;
+  }
+
   function buildContext({
-    includeMasteryScore = false,
+    includeCmi5Category = false,
+    includeMoveOnCategory = false,
   } = {}) {
     const context = cloneJson(launchData.contextTemplate);
-    const extensions = context.extensions || {};
 
     context.registration = launchContext.registration;
-    context.extensions = extensions;
+    context.extensions = context.extensions || {};
 
-    if (
-      includeMasteryScore
-      && launchData.masteryScore != null
-      && context.extensions[MASTERY_SCORE_EXTENSION_ID] == null
-    ) {
-      context.extensions[MASTERY_SCORE_EXTENSION_ID] = launchData.masteryScore;
+    if (includeCmi5Category) {
+      ensureCategoryActivity(context, CMI5_CATEGORY_ID);
+    }
+
+    if (includeMoveOnCategory) {
+      ensureCategoryActivity(context, MOVEON_CATEGORY_ID);
     }
 
     return context;
@@ -281,7 +337,8 @@ export function createCmi5Adapter({
   function buildStatement({
     verb,
     result = null,
-    includeMasteryScore = false,
+    includeCmi5Category = false,
+    includeMoveOnCategory = false,
   }) {
     return {
       id: createStatementId(),
@@ -297,7 +354,8 @@ export function createCmi5Adapter({
         objectType: 'Activity',
       },
       context: buildContext({
-        includeMasteryScore,
+        includeCmi5Category,
+        includeMoveOnCategory,
       }),
       timestamp: new Date(getNow()).toISOString(),
       ...(result ? { result } : {}),
@@ -307,12 +365,14 @@ export function createCmi5Adapter({
   async function postStatement({
     verb,
     result = null,
-    includeMasteryScore = false,
+    includeCmi5Category = false,
+    includeMoveOnCategory = false,
   }) {
     const statement = buildStatement({
       verb,
       result,
-      includeMasteryScore,
+      includeCmi5Category,
+      includeMoveOnCategory,
     });
     const response = await fetchFn(buildUrl(launchContext.endpoint, 'statements'), {
       method: 'POST',
@@ -362,12 +422,67 @@ export function createCmi5Adapter({
     };
   }
 
+  function getSuccessEvaluation(payload = {}) {
+    const score = latestScore || buildLatestScore(payload);
+    const masteryScore = normalizeNumber(launchData.masteryScore);
+
+    if (!score || masteryScore == null) {
+      return null;
+    }
+
+    return {
+      score,
+      passed: score.scaled >= masteryScore,
+    };
+  }
+
+  async function postCmi5DefinedStatement({
+    verb,
+    result = null,
+    includeMoveOnCategory = false,
+  }) {
+    return postStatement({
+      verb,
+      result,
+      includeCmi5Category: true,
+      includeMoveOnCategory,
+    });
+  }
+
+  async function postPassFailStatement(successEvaluation, elapsedMs) {
+    return postCmi5DefinedStatement({
+      verb: successEvaluation.passed ? VERBS.passed : VERBS.failed,
+      includeMoveOnCategory: true,
+      result: {
+        score: {
+          raw: successEvaluation.score.raw,
+          min: successEvaluation.score.min,
+          max: successEvaluation.score.max,
+          scaled: successEvaluation.score.scaled,
+        },
+        success: successEvaluation.passed,
+        ...createDurationResult(elapsedMs),
+      },
+    });
+  }
+
+  async function postCompletedStatement(elapsedMs) {
+    return postCmi5DefinedStatement({
+      verb: VERBS.completed,
+      includeMoveOnCategory: true,
+      result: {
+        completion: true,
+        ...createDurationResult(elapsedMs),
+      },
+    });
+  }
+
   async function terminate(elapsedMs) {
     if (terminated) {
       return true;
     }
 
-    await postStatement({
+    await postCmi5DefinedStatement({
       verb: VERBS.terminated,
       result: createDurationResult(elapsedMs),
     });
@@ -404,6 +519,7 @@ export function createCmi5Adapter({
 
       await postStatement({
         verb: VERBS.initialized,
+        includeCmi5Category: true,
       });
       initialized = true;
       return true;
@@ -495,37 +611,32 @@ export function createCmi5Adapter({
         return terminate(payload.elapsedMs);
       }
 
-      await postStatement({
-        verb: VERBS.completed,
-        result: {
-          completion: true,
-          ...createDurationResult(payload.elapsedMs),
-        },
-      });
+      const moveOn = getMoveOn();
+      const successEvaluation = getSuccessEvaluation(payload);
 
-      const score = latestScore || buildLatestScore(payload);
-      if (score && launchData.masteryScore != null) {
-        const passed = score.scaled >= launchData.masteryScore;
-
-        await postStatement({
-          verb: passed ? VERBS.passed : VERBS.failed,
-          includeMasteryScore: true,
-          result: {
-            score: {
-              raw: score.raw,
-              min: score.min,
-              max: score.max,
-              scaled: score.scaled,
-            },
-            success: passed,
-            ...createDurationResult(payload.elapsedMs),
-          },
-        });
-      } else if (score) {
-        runtimeLogger.warn('CMI5 mastery score missing, skipping passed/failed', {
-          score: score.raw,
-        });
+      if (moveOn === MOVE_ON.Passed || moveOn === MOVE_ON.CompletedAndPassed) {
+        if (!successEvaluation) {
+          runtimeLogger.warn('CMI5 complete requires a pass/fail decision, but success cannot be determined', {
+            moveOn,
+            score: latestScore ? latestScore.raw : null,
+            masteryScore: launchData.masteryScore,
+          });
+          return false;
+        }
       }
+
+      if (moveOn === MOVE_ON.Passed) {
+        await postPassFailStatement(successEvaluation, payload.elapsedMs);
+        return terminate(payload.elapsedMs);
+      }
+
+      if (moveOn === MOVE_ON.CompletedAndPassed) {
+        await postPassFailStatement(successEvaluation, payload.elapsedMs);
+        await postCompletedStatement(payload.elapsedMs);
+        return terminate(payload.elapsedMs);
+      }
+
+      await postCompletedStatement(payload.elapsedMs);
       return terminate(payload.elapsedMs);
     },
     async timeout(payload = {}) {

--- a/src/runtime/adapters/cmi5.mjs
+++ b/src/runtime/adapters/cmi5.mjs
@@ -6,6 +6,7 @@ const LEARNER_PREFERENCES_PROFILE_ID = 'cmi5LearnerPreferences';
 const PROGRESS_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/result/extensions/progress';
 const CMI5_CATEGORY_ID = 'https://w3id.org/xapi/cmi5/context/categories/cmi5';
 const MOVEON_CATEGORY_ID = 'https://w3id.org/xapi/cmi5/context/categories/moveon';
+const MASTERY_SCORE_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/context/extensions/masteryscore';
 
 const MOVE_ON = {
   Completed: 'Completed',
@@ -317,6 +318,7 @@ export function createCmi5Adapter({
   function buildContext({
     includeCmi5Category = false,
     includeMoveOnCategory = false,
+    masteryScore = null,
   } = {}) {
     const context = cloneJson(launchData.contextTemplate);
 
@@ -331,6 +333,10 @@ export function createCmi5Adapter({
       ensureCategoryActivity(context, MOVEON_CATEGORY_ID);
     }
 
+    if (masteryScore != null) {
+      context.extensions[MASTERY_SCORE_EXTENSION_ID] = masteryScore;
+    }
+
     return context;
   }
 
@@ -339,6 +345,7 @@ export function createCmi5Adapter({
     result = null,
     includeCmi5Category = false,
     includeMoveOnCategory = false,
+    masteryScore = null,
   }) {
     return {
       id: createStatementId(),
@@ -356,6 +363,7 @@ export function createCmi5Adapter({
       context: buildContext({
         includeCmi5Category,
         includeMoveOnCategory,
+        masteryScore,
       }),
       timestamp: new Date(getNow()).toISOString(),
       ...(result ? { result } : {}),
@@ -367,12 +375,14 @@ export function createCmi5Adapter({
     result = null,
     includeCmi5Category = false,
     includeMoveOnCategory = false,
+    masteryScore = null,
   }) {
     const statement = buildStatement({
       verb,
       result,
       includeCmi5Category,
       includeMoveOnCategory,
+      masteryScore,
     });
     const response = await fetchFn(buildUrl(launchContext.endpoint, 'statements'), {
       method: 'POST',
@@ -440,19 +450,24 @@ export function createCmi5Adapter({
     verb,
     result = null,
     includeMoveOnCategory = false,
+    masteryScore = null,
   }) {
     return postStatement({
       verb,
       result,
       includeCmi5Category: true,
       includeMoveOnCategory,
+      masteryScore,
     });
   }
 
   async function postPassFailStatement(successEvaluation, elapsedMs) {
+    const masteryScore = normalizeNumber(launchData.masteryScore);
+
     return postCmi5DefinedStatement({
       verb: successEvaluation.passed ? VERBS.passed : VERBS.failed,
       includeMoveOnCategory: true,
+      masteryScore,
       result: {
         score: {
           raw: successEvaluation.score.raw,

--- a/src/runtime/adapters/cmi5.mjs
+++ b/src/runtime/adapters/cmi5.mjs
@@ -1,0 +1,540 @@
+/* eslint-disable import/prefer-default-export */
+
+const XAPI_VERSION = '1.0.3';
+const LAUNCH_DATA_STATE_ID = 'LMS.LaunchData';
+const LEARNER_PREFERENCES_PROFILE_ID = 'cmi5LearnerPreferences';
+const PROGRESS_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/result/extensions/progress';
+const MASTERY_SCORE_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/context/extensions/masteryscore';
+
+const VERBS = {
+  initialized: {
+    id: 'http://adlnet.gov/expapi/verbs/initialized',
+    display: 'initialized',
+  },
+  progressed: {
+    id: 'http://adlnet.gov/expapi/verbs/progressed',
+    display: 'progressed',
+  },
+  completed: {
+    id: 'http://adlnet.gov/expapi/verbs/completed',
+    display: 'completed',
+  },
+  passed: {
+    id: 'http://adlnet.gov/expapi/verbs/passed',
+    display: 'passed',
+  },
+  failed: {
+    id: 'http://adlnet.gov/expapi/verbs/failed',
+    display: 'failed',
+  },
+  terminated: {
+    id: 'http://adlnet.gov/expapi/verbs/terminated',
+    display: 'terminated',
+  },
+};
+
+function ensureTrailingSlash(value) {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function buildUrl(endpoint, pathname, params = {}) {
+  const url = new URL(pathname, ensureTrailingSlash(endpoint));
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value != null) {
+      searchParams.set(key, value);
+    }
+  });
+
+  url.search = searchParams.toString();
+  return url.toString();
+}
+
+function cloneJson(value) {
+  if (value == null) {
+    return {};
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+function defaultStatementId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
+    const randomValue = Math.floor(Math.random() * 16);
+    const resolved = character === 'x'
+      ? randomValue
+      : [8, 9, 10, 11][Math.floor(Math.random() * 4)];
+
+    return resolved.toString(16);
+  });
+}
+
+function millisecondsToDuration(milliseconds) {
+  let seconds = Math.round(milliseconds / 1000);
+
+  let s = seconds % 60;
+  seconds -= s;
+  if (s < 10) {
+    s = `0${s}`;
+  }
+
+  let m = (seconds / 60) % 60;
+  if (m < 10) {
+    m = `0${m}`;
+  }
+
+  let h = Math.floor(seconds / 3600);
+  if (h < 10) {
+    h = `0${h}`;
+  }
+
+  return `PT${h}H${m}M${s}S`;
+}
+
+function normalizeNumber(value) {
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function normalizeScaledScore(score, scoreMin, scoreMax) {
+  const rawScore = normalizeNumber(score);
+  const minScore = normalizeNumber(scoreMin);
+  const maxScore = normalizeNumber(scoreMax);
+
+  if (rawScore == null || minScore == null || maxScore == null) {
+    return null;
+  }
+
+  const span = maxScore - minScore;
+  if (span <= 0) {
+    return null;
+  }
+
+  return Number(((rawScore - minScore) / span).toFixed(4));
+}
+
+function createNoopLogger(logger = {}) {
+  return {
+    debug: typeof logger.debug === 'function' ? logger.debug : () => {},
+    info: typeof logger.info === 'function' ? logger.info : () => {},
+    warn: typeof logger.warn === 'function' ? logger.warn : () => {},
+    error: typeof logger.error === 'function' ? logger.error : () => {},
+  };
+}
+
+export function createCmi5Adapter({
+  launchContext,
+  fetchFn = (...args) => fetch(...args),
+  logger = {},
+  getNow = () => Date.now(),
+  createStatementId = defaultStatementId,
+} = {}) {
+  const runtimeLogger = createNoopLogger(logger);
+
+  let authToken = null;
+  let launchData = null;
+  let learnerPreferences = null;
+  let bootPromise = null;
+  let initialized = false;
+  let terminated = false;
+  let latestScore = null;
+
+  function getActorString() {
+    if (typeof launchContext.actor === 'string' && launchContext.actor.length > 0) {
+      return launchContext.actor;
+    }
+
+    return JSON.stringify(launchContext.actorJson);
+  }
+
+  function createHeaders({
+    includeContentType = false,
+  } = {}) {
+    return {
+      Authorization: `Basic ${authToken}`,
+      'X-Experience-API-Version': XAPI_VERSION,
+      ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
+    };
+  }
+
+  async function readJsonResponse(response, {
+    allowNotFound = false,
+  } = {}) {
+    if (allowNotFound && response.status === 404) {
+      return null;
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(body['error-text'] || `CMI5 request failed with status ${response.status}`);
+    }
+
+    return body;
+  }
+
+  async function fetchToken() {
+    const response = await fetchFn(launchContext.fetch, {
+      method: 'POST',
+    });
+    const body = await readJsonResponse(response);
+    if (body['error-code']) {
+      throw new Error(body['error-text'] || `CMI5 token fetch error ${body['error-code']}`);
+    }
+    const token = body['auth-token'];
+
+    if (!token) {
+      throw new Error('CMI5 token fetch did not return "auth-token"');
+    }
+
+    return token;
+  }
+
+  async function fetchLaunchData() {
+    const response = await fetchFn(buildUrl(launchContext.endpoint, 'activities/state', {
+      activityId: launchContext.activityId,
+      agent: getActorString(),
+      registration: launchContext.registration,
+      stateId: LAUNCH_DATA_STATE_ID,
+    }), {
+      headers: createHeaders(),
+    });
+    const data = await readJsonResponse(response);
+
+    if (!data || !data.contextTemplate || !data.launchMode) {
+      throw new Error('CMI5 launch data is missing required fields');
+    }
+
+    return data;
+  }
+
+  async function fetchLearnerPreferences() {
+    const response = await fetchFn(buildUrl(launchContext.endpoint, 'agents/profile', {
+      agent: getActorString(),
+      profileId: LEARNER_PREFERENCES_PROFILE_ID,
+    }), {
+      headers: createHeaders(),
+    });
+
+    return readJsonResponse(response, {
+      allowNotFound: true,
+    });
+  }
+
+  async function ensureBootstrapped() {
+    if (bootPromise) {
+      return bootPromise;
+    }
+
+    bootPromise = (async () => {
+      authToken = await fetchToken();
+      launchData = await fetchLaunchData();
+      learnerPreferences = await fetchLearnerPreferences();
+
+      runtimeLogger.info('CMI5 launch data ready', {
+        launchMode: launchData.launchMode,
+        masteryScore: launchData.masteryScore,
+        hasLearnerPreferences: learnerPreferences != null,
+      });
+
+      return {
+        authToken,
+        launchData,
+        learnerPreferences,
+      };
+    })().catch((error) => {
+      bootPromise = null;
+      throw error;
+    });
+
+    return bootPromise;
+  }
+
+  function buildContext({
+    includeMasteryScore = false,
+  } = {}) {
+    const context = cloneJson(launchData.contextTemplate);
+    const extensions = context.extensions || {};
+
+    context.registration = launchContext.registration;
+    context.extensions = extensions;
+
+    if (
+      includeMasteryScore
+      && launchData.masteryScore != null
+      && context.extensions[MASTERY_SCORE_EXTENSION_ID] == null
+    ) {
+      context.extensions[MASTERY_SCORE_EXTENSION_ID] = launchData.masteryScore;
+    }
+
+    return context;
+  }
+
+  function buildStatement({
+    verb,
+    result = null,
+    includeMasteryScore = false,
+  }) {
+    return {
+      id: createStatementId(),
+      actor: launchContext.actorJson,
+      verb: {
+        id: verb.id,
+        display: {
+          'en-US': verb.display,
+        },
+      },
+      object: {
+        id: launchContext.activityId,
+        objectType: 'Activity',
+      },
+      context: buildContext({
+        includeMasteryScore,
+      }),
+      timestamp: new Date(getNow()).toISOString(),
+      ...(result ? { result } : {}),
+    };
+  }
+
+  async function postStatement({
+    verb,
+    result = null,
+    includeMasteryScore = false,
+  }) {
+    const statement = buildStatement({
+      verb,
+      result,
+      includeMasteryScore,
+    });
+    const response = await fetchFn(buildUrl(launchContext.endpoint, 'statements'), {
+      method: 'POST',
+      headers: createHeaders({
+        includeContentType: true,
+      }),
+      body: JSON.stringify(statement),
+    });
+
+    await readJsonResponse(response);
+    return statement;
+  }
+
+  function isNormalLaunchMode() {
+    return launchData && launchData.launchMode === 'Normal';
+  }
+
+  function createDurationResult(elapsedMs) {
+    if (elapsedMs == null) {
+      return {};
+    }
+
+    return {
+      duration: millisecondsToDuration(elapsedMs),
+    };
+  }
+
+  function buildLatestScore(payload = {}) {
+    const raw = normalizeNumber(
+      payload.score != null
+        ? payload.score
+        : payload.currentScore,
+    );
+    const min = normalizeNumber(payload.scoreMin);
+    const max = normalizeNumber(payload.scoreMax);
+    const scaled = normalizeScaledScore(raw, min, max);
+
+    if (raw == null || min == null || max == null || scaled == null) {
+      return null;
+    }
+
+    return {
+      raw,
+      min,
+      max,
+      scaled,
+    };
+  }
+
+  async function terminate(elapsedMs) {
+    if (terminated) {
+      return true;
+    }
+
+    await postStatement({
+      verb: VERBS.terminated,
+      result: createDurationResult(elapsedMs),
+    });
+    terminated = true;
+
+    if (
+      launchData
+      && launchData.returnURL
+      && typeof window !== 'undefined'
+      && window.location
+      && typeof window.location.assign === 'function'
+    ) {
+      window.location.assign(launchData.returnURL);
+    }
+
+    return true;
+  }
+
+  function createIgnoredResult() {
+    return {
+      ok: true,
+      ignored: true,
+    };
+  }
+
+  return {
+    protocol: 'CMI5',
+    async start() {
+      await ensureBootstrapped();
+
+      if (initialized) {
+        return true;
+      }
+
+      await postStatement({
+        verb: VERBS.initialized,
+      });
+      initialized = true;
+      return true;
+    },
+    async setProgress({
+      progressPercent,
+    }) {
+      await ensureBootstrapped();
+
+      if (!initialized || terminated) {
+        return createIgnoredResult();
+      }
+
+      if (!isNormalLaunchMode()) {
+        runtimeLogger.warn('Ignoring CMI5 progress outside Normal launch mode', {
+          launchMode: launchData.launchMode,
+        });
+        return createIgnoredResult();
+      }
+
+      const percent = Math.round(normalizeNumber(progressPercent) || 0);
+      if (percent <= 0 || percent >= 100) {
+        runtimeLogger.debug('Ignoring CMI5 progress outside 1-99 range', {
+          progressPercent: percent,
+        });
+        return createIgnoredResult();
+      }
+
+      await postStatement({
+        verb: VERBS.progressed,
+        result: {
+          extensions: {
+            [PROGRESS_EXTENSION_ID]: percent,
+          },
+        },
+      });
+      return true;
+    },
+    async setScore(payload) {
+      await ensureBootstrapped();
+
+      if (!initialized || terminated) {
+        return createIgnoredResult();
+      }
+
+      if (!isNormalLaunchMode()) {
+        runtimeLogger.warn('Ignoring CMI5 score outside Normal launch mode', {
+          launchMode: launchData.launchMode,
+        });
+        return createIgnoredResult();
+      }
+
+      latestScore = buildLatestScore(payload);
+      runtimeLogger.info('CMI5 score cached', {
+        score: latestScore ? latestScore.raw : null,
+      });
+      return createIgnoredResult();
+    },
+    async markIncomplete() {
+      await ensureBootstrapped();
+
+      if (!initialized || terminated) {
+        return createIgnoredResult();
+      }
+
+      if (!isNormalLaunchMode()) {
+        runtimeLogger.warn('Ignoring CMI5 incomplete outside Normal launch mode', {
+          launchMode: launchData.launchMode,
+        });
+        return createIgnoredResult();
+      }
+
+      runtimeLogger.info('CMI5 incomplete cached', {
+        launchMode: launchData.launchMode,
+      });
+      return createIgnoredResult();
+    },
+    async complete(payload = {}) {
+      await ensureBootstrapped();
+
+      if (!initialized) {
+        return false;
+      }
+
+      if (!isNormalLaunchMode()) {
+        runtimeLogger.warn('CMI5 complete is terminating without satisfaction statements', {
+          launchMode: launchData.launchMode,
+        });
+        return terminate(payload.elapsedMs);
+      }
+
+      await postStatement({
+        verb: VERBS.completed,
+        result: {
+          completion: true,
+          ...createDurationResult(payload.elapsedMs),
+        },
+      });
+
+      const score = latestScore || buildLatestScore(payload);
+      if (score && launchData.masteryScore != null) {
+        const passed = score.scaled >= launchData.masteryScore;
+
+        await postStatement({
+          verb: passed ? VERBS.passed : VERBS.failed,
+          includeMasteryScore: true,
+          result: {
+            score: {
+              raw: score.raw,
+              min: score.min,
+              max: score.max,
+              scaled: score.scaled,
+            },
+            success: passed,
+            ...createDurationResult(payload.elapsedMs),
+          },
+        });
+      } else if (score) {
+        runtimeLogger.warn('CMI5 mastery score missing, skipping passed/failed', {
+          score: score.raw,
+        });
+      }
+      return terminate(payload.elapsedMs);
+    },
+    async timeout(payload = {}) {
+      await ensureBootstrapped();
+
+      if (!initialized) {
+        return false;
+      }
+      return terminate(payload.elapsedMs);
+    },
+  };
+}

--- a/src/runtime/adapters/local.mjs
+++ b/src/runtime/adapters/local.mjs
@@ -1,0 +1,118 @@
+/* eslint-disable import/prefer-default-export */
+
+function parseStoredNumber(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function setStoredValue(storage, key, value) {
+  if (!storage || typeof storage.setItem !== 'function') {
+    return;
+  }
+
+  storage.setItem(key, value);
+}
+
+export function createLocalAdapter({
+  enabled = false,
+  unitId = null,
+  storage = null,
+  send = null,
+} = {}) {
+  function canPersist() {
+    return enabled && unitId != null && storage != null;
+  }
+
+  function synchronize(eventName, payload) {
+    if (typeof send === 'function') {
+      send(eventName, payload);
+    }
+  }
+
+  function setElapsedTime(elapsedMs) {
+    if (!canPersist()) {
+      return;
+    }
+
+    setStoredValue(storage, `${unitId}_total_time`, elapsedMs);
+  }
+
+  return {
+    protocol: 'Local',
+    restore() {
+      if (!canPersist() || typeof storage.getItem !== 'function') {
+        return null;
+      }
+
+      const elapsedMs = parseStoredNumber(storage.getItem(`${unitId}_total_time`));
+      const progressRatio = parseStoredNumber(storage.getItem(`${unitId}_progress`));
+      const score = parseStoredNumber(storage.getItem(`${unitId}_score`));
+
+      if (elapsedMs == null && progressRatio == null && score == null) {
+        return null;
+      }
+
+      return {
+        elapsedMs,
+        progressRatio,
+        progressPercent: progressRatio == null ? null : progressRatio * 100,
+        score,
+      };
+    },
+    start() {
+      return true;
+    },
+    setProgress({
+      elapsedMs,
+      progressRatio,
+    }) {
+      setElapsedTime(elapsedMs);
+
+      if (canPersist()) {
+        setStoredValue(storage, `${unitId}_progress`, progressRatio);
+        synchronize('synchronize', [progressRatio, 'syncProgress', true]);
+      }
+      return true;
+    },
+    setScore({
+      elapsedMs,
+      score,
+      scoreMin,
+      scoreMax,
+    }) {
+      setElapsedTime(elapsedMs);
+
+      if (canPersist()) {
+        setStoredValue(storage, `${unitId}_score`, score);
+        synchronize('synchronize', [
+          (score * 100) / (scoreMax - scoreMin),
+          'syncScore',
+          true,
+        ]);
+      }
+      return true;
+    },
+    markIncomplete({
+      elapsedMs,
+    }) {
+      setElapsedTime(elapsedMs);
+      return true;
+    },
+    complete({
+      elapsedMs,
+    }) {
+      setElapsedTime(elapsedMs);
+      return true;
+    },
+    timeout({
+      elapsedMs,
+    }) {
+      setElapsedTime(elapsedMs);
+      return true;
+    },
+  };
+}

--- a/src/runtime/adapters/local.mjs
+++ b/src/runtime/adapters/local.mjs
@@ -20,11 +20,20 @@ function setStoredValue(storage, key, value) {
 export function createLocalAdapter({
   enabled = false,
   unitId = null,
+  storageKeyPrefix = null,
   storage = null,
   send = null,
 } = {}) {
+  function getStoragePrefix() {
+    if (typeof storageKeyPrefix === 'string' && storageKeyPrefix.length > 0) {
+      return storageKeyPrefix;
+    }
+
+    return unitId;
+  }
+
   function canPersist() {
-    return enabled && unitId != null && storage != null;
+    return enabled && getStoragePrefix() != null && storage != null;
   }
 
   function synchronize(eventName, payload) {
@@ -38,7 +47,7 @@ export function createLocalAdapter({
       return;
     }
 
-    setStoredValue(storage, `${unitId}_total_time`, elapsedMs);
+    setStoredValue(storage, `${getStoragePrefix()}_total_time`, elapsedMs);
   }
 
   return {
@@ -48,9 +57,10 @@ export function createLocalAdapter({
         return null;
       }
 
-      const elapsedMs = parseStoredNumber(storage.getItem(`${unitId}_total_time`));
-      const progressRatio = parseStoredNumber(storage.getItem(`${unitId}_progress`));
-      const score = parseStoredNumber(storage.getItem(`${unitId}_score`));
+      const storagePrefix = getStoragePrefix();
+      const elapsedMs = parseStoredNumber(storage.getItem(`${storagePrefix}_total_time`));
+      const progressRatio = parseStoredNumber(storage.getItem(`${storagePrefix}_progress`));
+      const score = parseStoredNumber(storage.getItem(`${storagePrefix}_score`));
 
       if (elapsedMs == null && progressRatio == null && score == null) {
         return null;
@@ -73,7 +83,7 @@ export function createLocalAdapter({
       setElapsedTime(elapsedMs);
 
       if (canPersist()) {
-        setStoredValue(storage, `${unitId}_progress`, progressRatio);
+        setStoredValue(storage, `${getStoragePrefix()}_progress`, progressRatio);
         synchronize('synchronize', [progressRatio, 'syncProgress', true]);
       }
       return true;
@@ -87,7 +97,7 @@ export function createLocalAdapter({
       setElapsedTime(elapsedMs);
 
       if (canPersist()) {
-        setStoredValue(storage, `${unitId}_score`, score);
+        setStoredValue(storage, `${getStoragePrefix()}_score`, score);
         synchronize('synchronize', [
           (score * 100) / (scoreMax - scoreMin),
           'syncScore',

--- a/src/runtime/adapters/scorm12.mjs
+++ b/src/runtime/adapters/scorm12.mjs
@@ -1,0 +1,164 @@
+/* eslint-disable import/prefer-default-export */
+
+function millisecondsToTime(milliseconds) {
+  let seconds = Math.round(milliseconds / 1000);
+
+  let s = seconds % 60;
+  seconds -= s;
+  if (s < 10) {
+    s = `0${s}`;
+  }
+
+  let m = (seconds / 60) % 60;
+  if (m < 10) {
+    m = `0${m}`;
+  }
+
+  let h = Math.floor(seconds / 3600);
+  if (h < 10) {
+    h = `0${h}`;
+  }
+
+  return `${h}:${m}:${s}`;
+}
+
+function isSuccessfulResult(result) {
+  return result === true || result === 'true';
+}
+
+function isFailureResult(result, errorDetails) {
+  if (result === false || result === 'false') {
+    return true;
+  }
+
+  if (!errorDetails || errorDetails.code == null) {
+    return false;
+  }
+
+  return `${errorDetails.code}` !== '0';
+}
+
+export function createScorm12Adapter({
+  api = null,
+  logger = {},
+} = {}) {
+  function getErrorDetails() {
+    if (!api || typeof api.LMSGetLastError !== 'function') {
+      return null;
+    }
+
+    const code = api.LMSGetLastError();
+    return {
+      code,
+      errorString: typeof api.LMSGetErrorString === 'function'
+        ? api.LMSGetErrorString(code)
+        : null,
+      diagnostic: typeof api.LMSGetDiagnostic === 'function'
+        ? api.LMSGetDiagnostic(code)
+        : null,
+    };
+  }
+
+  function log(level, message, details) {
+    if (logger && typeof logger[level] === 'function') {
+      logger[level](message, details);
+    }
+  }
+
+  function call(method, ...args) {
+    if (!api || typeof api[method] !== 'function') {
+      return null;
+    }
+
+    const result = api[method](...args);
+    const error = getErrorDetails();
+    const payload = {
+      protocol: 'SCORM 1.2',
+      method,
+      args,
+      result,
+      error,
+    };
+
+    if (isFailureResult(result, error)) {
+      log('error', 'SCORM call failed', payload);
+    } else {
+      log('debug', 'SCORM call', payload);
+    }
+
+    return result;
+  }
+
+  return {
+    protocol: 'SCORM 1.2',
+    start({
+      scoreMin,
+      scoreMax,
+    }) {
+      const initResult = call('LMSInitialize', '');
+      if (!isSuccessfulResult(initResult)) {
+        return false;
+      }
+
+      call('LMSSetValue', 'cmi.core.lesson_status', 'incomplete');
+      call('LMSSetValue', 'cmi.core.score.min', scoreMin);
+      call('LMSSetValue', 'cmi.core.score.max', scoreMax);
+      call('LMSCommit', '');
+      return true;
+    },
+    setProgress({
+      elapsedMs,
+      progressPercent,
+    }) {
+      call('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(elapsedMs));
+      const progressResult = call(
+        'LMSSetValue',
+        'cmi.core.lesson_location',
+        `${Math.round(progressPercent)}`,
+      );
+      const commitResult = call('LMSCommit', '');
+
+      return isSuccessfulResult(progressResult) && isSuccessfulResult(commitResult);
+    },
+    setScore({
+      elapsedMs,
+      score,
+    }) {
+      call('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(elapsedMs));
+      const scoreResult = call('LMSSetValue', 'cmi.core.score.raw', score);
+      const commitResult = call('LMSCommit', '');
+
+      return isSuccessfulResult(scoreResult) && isSuccessfulResult(commitResult);
+    },
+    markIncomplete({
+      elapsedMs,
+    }) {
+      const statusResult = call('LMSSetValue', 'cmi.core.lesson_status', 'incomplete');
+      call('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(elapsedMs));
+      const commitResult = call('LMSCommit', '');
+
+      return isSuccessfulResult(statusResult) && isSuccessfulResult(commitResult);
+    },
+    complete({
+      elapsedMs,
+    }) {
+      call('LMSSetValue', 'cmi.core.session_time', millisecondsToTime(elapsedMs));
+      const statusResult = call('LMSSetValue', 'cmi.core.lesson_status', 'completed');
+      const commitResult = call('LMSCommit', '');
+      const finishResult = call('LMSFinish', '');
+
+      return (
+        isSuccessfulResult(statusResult)
+        && isSuccessfulResult(commitResult)
+        && isSuccessfulResult(finishResult)
+      );
+    },
+    timeout() {
+      call('LMSSetValue', 'cmi.core.exit', 'time-out');
+      const commitResult = call('LMSCommit', '');
+      const finishResult = call('LMSFinish', '');
+
+      return isSuccessfulResult(commitResult) && isSuccessfulResult(finishResult);
+    },
+  };
+}

--- a/src/runtime/adapters/scorm2004.mjs
+++ b/src/runtime/adapters/scorm2004.mjs
@@ -1,0 +1,166 @@
+/* eslint-disable import/prefer-default-export */
+
+function millisecondsToTime2004(milliseconds) {
+  let seconds = Math.round(milliseconds / 1000);
+
+  let s = seconds % 60;
+  seconds -= s;
+  if (s < 10) {
+    s = `0${s}`;
+  }
+
+  let m = (seconds / 60) % 60;
+  if (m < 10) {
+    m = `0${m}`;
+  }
+
+  let h = Math.floor(seconds / 3600);
+  if (h < 10) {
+    h = `0${h}`;
+  }
+
+  return `PT${h}H${m}M${s}S`;
+}
+
+function isSuccessfulResult(result) {
+  return result === true || result === 'true';
+}
+
+function isFailureResult(result, errorDetails) {
+  if (result === false || result === 'false') {
+    return true;
+  }
+
+  if (!errorDetails || errorDetails.code == null) {
+    return false;
+  }
+
+  return `${errorDetails.code}` !== '0';
+}
+
+export function createScorm2004Adapter({
+  api = null,
+  logger = {},
+} = {}) {
+  function getErrorDetails() {
+    if (!api || typeof api.GetLastError !== 'function') {
+      return null;
+    }
+
+    const code = api.GetLastError();
+    return {
+      code,
+      errorString: typeof api.GetErrorString === 'function'
+        ? api.GetErrorString(code)
+        : null,
+      diagnostic: typeof api.GetDiagnostic === 'function'
+        ? api.GetDiagnostic(code)
+        : null,
+    };
+  }
+
+  function log(level, message, details) {
+    if (logger && typeof logger[level] === 'function') {
+      logger[level](message, details);
+    }
+  }
+
+  function call(method, ...args) {
+    if (!api || typeof api[method] !== 'function') {
+      return null;
+    }
+
+    const result = api[method](...args);
+    const error = getErrorDetails();
+    const payload = {
+      protocol: 'SCORM 2004',
+      method,
+      args,
+      result,
+      error,
+    };
+
+    if (isFailureResult(result, error)) {
+      log('error', 'SCORM call failed', payload);
+    } else {
+      log('debug', 'SCORM call', payload);
+    }
+
+    return result;
+  }
+
+  return {
+    protocol: 'SCORM 2004',
+    start({
+      scoreMin,
+      scoreMax,
+    }) {
+      const initResult = call('Initialize', '');
+      if (!isSuccessfulResult(initResult)) {
+        return false;
+      }
+
+      call('SetValue', 'cmi.score.min', scoreMin);
+      call('SetValue', 'cmi.score.max', scoreMax);
+      call('Commit', '');
+      return true;
+    },
+    setProgress({
+      elapsedMs,
+      progressRatio,
+    }) {
+      call('SetValue', 'cmi.session_time', millisecondsToTime2004(elapsedMs));
+      const progressResult = call('SetValue', 'cmi.progress_measure', progressRatio);
+      const commitResult = call('Commit', '');
+
+      return isSuccessfulResult(progressResult) && isSuccessfulResult(commitResult);
+    },
+    setScore({
+      elapsedMs,
+      score,
+      scoreMax,
+    }) {
+      call('SetValue', 'cmi.session_time', millisecondsToTime2004(elapsedMs));
+      const rawResult = call('SetValue', 'cmi.score.raw', score);
+      const scaledResult = call('SetValue', 'cmi.score.scaled', score / parseInt(scoreMax, 10));
+      const commitResult = call('Commit', '');
+
+      return (
+        isSuccessfulResult(rawResult)
+        && isSuccessfulResult(scaledResult)
+        && isSuccessfulResult(commitResult)
+      );
+    },
+    markIncomplete({
+      elapsedMs,
+    }) {
+      const statusResult = call('SetValue', 'cmi.completion_status', 'incomplete');
+      call('SetValue', 'cmi.session_time', millisecondsToTime2004(elapsedMs));
+      const commitResult = call('Commit', '');
+
+      return isSuccessfulResult(statusResult) && isSuccessfulResult(commitResult);
+    },
+    complete({
+      elapsedMs,
+    }) {
+      call('SetValue', 'cmi.session_time', millisecondsToTime2004(elapsedMs));
+      const statusResult = call('SetValue', 'cmi.completion_status', 'completed');
+      const commitResult = call('Commit', '');
+      const terminateResult = call('Terminate', '');
+
+      return (
+        isSuccessfulResult(statusResult)
+        && isSuccessfulResult(commitResult)
+        && isSuccessfulResult(terminateResult)
+      );
+    },
+    timeout() {
+      call('SetValue', 'cmi.core.exit', 'time-out');
+      call('SetValue', 'cmi.exit', 'time-out');
+      const commitResult = call('Commit', '');
+      const terminateResult = call('Terminate', '');
+
+      return isSuccessfulResult(commitResult) && isSuccessfulResult(terminateResult);
+    },
+  };
+}

--- a/src/runtime/select-protocol.mjs
+++ b/src/runtime/select-protocol.mjs
@@ -2,7 +2,6 @@ const REQUIRED_CMI5_PARAMS = [
   'endpoint',
   'fetch',
   'registration',
-  'activityid',
   'actor',
 ];
 
@@ -40,12 +39,17 @@ function parseActorJson(actorValue) {
 export function parseCmi5LaunchContext(queryString = '') {
   const searchParams = new URLSearchParams(queryString);
   const values = {};
+  const activityId = searchParams.get('activityId') || searchParams.get('activityid');
 
   REQUIRED_CMI5_PARAMS.forEach((key) => {
     values[key] = searchParams.get(key);
   });
 
   const missingParams = REQUIRED_CMI5_PARAMS.filter((key) => !hasValue(values[key]));
+  if (!hasValue(activityId)) {
+    missingParams.push('activityId');
+  }
+
   if (missingParams.length > 0) {
     return null;
   }
@@ -59,8 +63,8 @@ export function parseCmi5LaunchContext(queryString = '') {
     endpoint: values.endpoint,
     fetch: values.fetch,
     registration: values.registration,
-    activityId: values.activityid,
-    activityid: values.activityid,
+    activityId,
+    activityid: activityId,
     actor: values.actor,
     actorJson,
   };

--- a/src/runtime/select-protocol.mjs
+++ b/src/runtime/select-protocol.mjs
@@ -1,0 +1,116 @@
+const REQUIRED_CMI5_PARAMS = [
+  'endpoint',
+  'fetch',
+  'registration',
+  'activityid',
+  'actor',
+];
+
+function getQueryString({
+  queryString = '',
+  locationSearch = '',
+} = {}) {
+  if (typeof queryString === 'string' && queryString.length > 0) {
+    return queryString;
+  }
+
+  if (typeof locationSearch === 'string' && locationSearch.length > 0) {
+    return locationSearch;
+  }
+
+  return '';
+}
+
+function hasValue(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function parseActorJson(actorValue) {
+  if (!hasValue(actorValue)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(actorValue);
+  } catch (error) {
+    return null;
+  }
+}
+
+export function parseCmi5LaunchContext(queryString = '') {
+  const searchParams = new URLSearchParams(queryString);
+  const values = {};
+
+  REQUIRED_CMI5_PARAMS.forEach((key) => {
+    values[key] = searchParams.get(key);
+  });
+
+  const missingParams = REQUIRED_CMI5_PARAMS.filter((key) => !hasValue(values[key]));
+  if (missingParams.length > 0) {
+    return null;
+  }
+
+  const actorJson = parseActorJson(values.actor);
+  if (actorJson == null) {
+    return null;
+  }
+
+  return {
+    endpoint: values.endpoint,
+    fetch: values.fetch,
+    registration: values.registration,
+    activityId: values.activityid,
+    activityid: values.activityid,
+    actor: values.actor,
+    actorJson,
+  };
+}
+
+export function selectProtocol(options = {}) {
+  const queryString = getQueryString(options);
+  const hasScorm2004 = options.hasScorm2004 === true || !!options.scorm2004Api;
+  const hasScorm12 = options.hasScorm12 === true || !!options.scorm12Api;
+  const cmi5 = parseCmi5LaunchContext(queryString);
+
+  if (cmi5 != null) {
+    return {
+      protocol: 'cmi5',
+      context: {
+        cmi5,
+        hasScorm2004,
+        hasScorm12,
+      },
+    };
+  }
+
+  if (hasScorm2004) {
+    return {
+      protocol: 'scorm2004',
+      context: {
+        cmi5: null,
+        hasScorm2004,
+        hasScorm12,
+      },
+    };
+  }
+
+  if (hasScorm12) {
+    return {
+      protocol: 'scorm12',
+      context: {
+        cmi5: null,
+        hasScorm2004,
+        hasScorm12,
+      },
+    };
+  }
+
+  return {
+    protocol: 'local',
+    context: {
+      cmi5: null,
+      hasScorm2004,
+      hasScorm12,
+    },
+  };
+}

--- a/src/runtime/tracker-core.mjs
+++ b/src/runtime/tracker-core.mjs
@@ -22,6 +22,20 @@ function createNoopLogger(logger = {}) {
   };
 }
 
+function normalizeActionResult(result) {
+  if (result && typeof result === 'object') {
+    return {
+      ok: result.ok === true,
+      ignored: result.ignored === true,
+    };
+  }
+
+  return {
+    ok: result === true,
+    ignored: false,
+  };
+}
+
 export function createTracker({
   adapter = null,
   companionAdapters = [],
@@ -66,26 +80,32 @@ export function createTracker({
     };
   }
 
-  function runCompanionAdapters(methodName, payload) {
-    companionAdapters.forEach((companionAdapter) => {
+  async function runCompanionAdapters(methodName, payload) {
+    await Promise.all(companionAdapters.map((companionAdapter) => {
       if (!companionAdapter || typeof companionAdapter[methodName] !== 'function') {
-        return;
+        return null;
       }
 
-      companionAdapter[methodName](payload);
-    });
+      return companionAdapter[methodName](payload);
+    }));
   }
 
-  function restoreState() {
+  async function restoreState() {
     const adapters = [adapter, ...companionAdapters];
     const restored = {};
 
-    adapters.forEach((currentAdapter) => {
+    const restoredStates = await Promise.all(adapters.map((currentAdapter) => {
       if (!currentAdapter || typeof currentAdapter.restore !== 'function') {
-        return;
+        return null;
       }
 
-      const nextState = currentAdapter.restore() || {};
+      return currentAdapter.restore();
+    }));
+
+    restoredStates.forEach((nextState) => {
+      if (!nextState) {
+        return;
+      }
 
       if (restored.elapsedMs == null && nextState.elapsedMs != null) {
         restored.elapsedMs = nextState.elapsedMs;
@@ -131,7 +151,7 @@ export function createTracker({
 
   return {
     getState,
-    start() {
+    async start() {
       const {
         scoreMin,
         scoreMax,
@@ -156,10 +176,10 @@ export function createTracker({
         return true;
       }
 
-      const restored = restoreState();
+      const restored = await restoreState();
       startTime = restored.elapsedMs == null ? getNow() : getNow() - restored.elapsedMs;
 
-      const didStart = adapter.start(getBasePayload());
+      const { ok: didStart } = normalizeActionResult(await adapter.start(getBasePayload()));
       if (!didStart) {
         runtimeLogger.error('Session start failed', {
           protocol: getProtocol(),
@@ -173,12 +193,12 @@ export function createTracker({
       sessionFinished = false;
 
       if (restored.progressPercent != null) {
-        this.progress(restored.progressPercent);
+        await this.progress(restored.progressPercent);
       }
 
       if (restored.score != null) {
         currentScore = normalizeScore(restored.score);
-        this.score(currentScore);
+        await this.score(currentScore);
       }
 
       runtimeLogger.info('Session started', {
@@ -191,7 +211,7 @@ export function createTracker({
       });
       return true;
     },
-    progress(value) {
+    async progress(value) {
       const progressPercent = normalizeProgressPercent(value);
       const progressRatio = progressPercent / 100;
 
@@ -203,13 +223,17 @@ export function createTracker({
         progressPercent,
         progressRatio,
       });
-      const didSync = adapter && typeof adapter.setProgress === 'function'
-        ? adapter.setProgress(payload)
-        : false;
+      const outcome = adapter && typeof adapter.setProgress === 'function'
+        ? normalizeActionResult(await adapter.setProgress(payload))
+        : normalizeActionResult(false);
 
-      runCompanionAdapters('setProgress', payload);
+      await runCompanionAdapters('setProgress', payload);
 
-      if (didSync) {
+      if (outcome.ignored) {
+        return outcome.ok;
+      }
+
+      if (outcome.ok) {
         runtimeLogger.info('Progress synced', {
           protocol: getProtocol(),
           progressPercent,
@@ -225,9 +249,9 @@ export function createTracker({
         });
       }
 
-      return didSync;
+      return outcome.ok;
     },
-    score(value) {
+    async score(value) {
       currentScore = normalizeScore(value);
 
       if (!ensureSessionStarted('score')) {
@@ -237,13 +261,17 @@ export function createTracker({
       const payload = getBasePayload({
         score: currentScore,
       });
-      const didSync = adapter && typeof adapter.setScore === 'function'
-        ? adapter.setScore(payload)
-        : false;
+      const outcome = adapter && typeof adapter.setScore === 'function'
+        ? normalizeActionResult(await adapter.setScore(payload))
+        : normalizeActionResult(false);
 
-      runCompanionAdapters('setScore', payload);
+      await runCompanionAdapters('setScore', payload);
 
-      if (didSync) {
+      if (outcome.ignored) {
+        return outcome.ok;
+      }
+
+      if (outcome.ok) {
         runtimeLogger.info('Score synced', {
           protocol: getProtocol(),
           score: currentScore,
@@ -261,29 +289,33 @@ export function createTracker({
         });
       }
 
-      return didSync;
+      return outcome.ok;
     },
-    incScore(value) {
+    async incScore(value) {
       currentScore += normalizeScore(value);
       return this.score(currentScore);
     },
-    decScore(value) {
+    async decScore(value) {
       currentScore -= normalizeScore(value);
       return this.score(currentScore);
     },
-    incomplete() {
+    async incomplete() {
       if (!ensureSessionStarted('incomplete')) {
         return false;
       }
 
       const payload = getBasePayload();
-      const didSync = adapter && typeof adapter.markIncomplete === 'function'
-        ? adapter.markIncomplete(payload)
-        : false;
+      const outcome = adapter && typeof adapter.markIncomplete === 'function'
+        ? normalizeActionResult(await adapter.markIncomplete(payload))
+        : normalizeActionResult(false);
 
-      runCompanionAdapters('markIncomplete', payload);
+      await runCompanionAdapters('markIncomplete', payload);
 
-      if (didSync) {
+      if (outcome.ignored) {
+        return outcome.ok;
+      }
+
+      if (outcome.ok) {
         runtimeLogger.info('Session marked incomplete', {
           protocol: getProtocol(),
           elapsedMs: payload.elapsedMs,
@@ -295,20 +327,20 @@ export function createTracker({
         });
       }
 
-      return didSync;
+      return outcome.ok;
     },
-    complete() {
+    async complete() {
       if (!ensureSessionStarted('complete')) {
         return false;
       }
 
       const payload = getBasePayload();
-      const didComplete = adapter && typeof adapter.complete === 'function'
-        ? adapter.complete(payload)
-        : false;
+      const { ok: didComplete } = adapter && typeof adapter.complete === 'function'
+        ? normalizeActionResult(await adapter.complete(payload))
+        : normalizeActionResult(false);
 
       if (didComplete) {
-        runCompanionAdapters('complete', payload);
+        await runCompanionAdapters('complete', payload);
         sessionStarted = false;
         sessionFinished = true;
         runtimeLogger.info('Session completed', {
@@ -324,18 +356,18 @@ export function createTracker({
       });
       return false;
     },
-    timedout() {
+    async timedout() {
       if (!ensureSessionStarted('timedout')) {
         return false;
       }
 
       const payload = getBasePayload();
-      const didTimeout = adapter && typeof adapter.timeout === 'function'
-        ? adapter.timeout(payload)
-        : false;
+      const { ok: didTimeout } = adapter && typeof adapter.timeout === 'function'
+        ? normalizeActionResult(await adapter.timeout(payload))
+        : normalizeActionResult(false);
 
       if (didTimeout) {
-        runCompanionAdapters('timeout', payload);
+        await runCompanionAdapters('timeout', payload);
         sessionStarted = false;
         sessionFinished = true;
         runtimeLogger.warn('Session timed out', {

--- a/src/runtime/tracker-core.mjs
+++ b/src/runtime/tracker-core.mjs
@@ -1,0 +1,355 @@
+/* eslint-disable import/prefer-default-export */
+
+const SCORE_MIN_KEY = 'score.min';
+const SCORE_MAX_KEY = 'score.max';
+
+function normalizeProgressPercent(value) {
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function normalizeScore(value) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function createNoopLogger(logger = {}) {
+  return {
+    debug: typeof logger.debug === 'function' ? logger.debug : () => {},
+    info: typeof logger.info === 'function' ? logger.info : () => {},
+    warn: typeof logger.warn === 'function' ? logger.warn : () => {},
+    error: typeof logger.error === 'function' ? logger.error : () => {},
+  };
+}
+
+export function createTracker({
+  adapter = null,
+  companionAdapters = [],
+  properties = {},
+  logger = {},
+  getNow = () => Date.now(),
+} = {}) {
+  const runtimeLogger = createNoopLogger(logger);
+
+  let startTime = null;
+  let currentScore = 0;
+  let sessionStarted = false;
+  let sessionFinished = false;
+
+  function getProtocol() {
+    return adapter && adapter.protocol ? adapter.protocol : null;
+  }
+
+  function getState() {
+    return {
+      protocol: getProtocol(),
+      sessionStarted,
+      sessionFinished,
+      startTime,
+      currentScore,
+    };
+  }
+
+  function getBasePayload(extra = {}) {
+    const scoreMin = properties[SCORE_MIN_KEY];
+    const scoreMax = properties[SCORE_MAX_KEY];
+
+    return {
+      ...extra,
+      properties,
+      protocol: getProtocol(),
+      scoreMin,
+      scoreMax,
+      currentScore,
+      startTime,
+      elapsedMs: startTime == null ? 0 : getNow() - startTime,
+    };
+  }
+
+  function runCompanionAdapters(methodName, payload) {
+    companionAdapters.forEach((companionAdapter) => {
+      if (!companionAdapter || typeof companionAdapter[methodName] !== 'function') {
+        return;
+      }
+
+      companionAdapter[methodName](payload);
+    });
+  }
+
+  function restoreState() {
+    const adapters = [adapter, ...companionAdapters];
+    const restored = {};
+
+    adapters.forEach((currentAdapter) => {
+      if (!currentAdapter || typeof currentAdapter.restore !== 'function') {
+        return;
+      }
+
+      const nextState = currentAdapter.restore() || {};
+
+      if (restored.elapsedMs == null && nextState.elapsedMs != null) {
+        restored.elapsedMs = nextState.elapsedMs;
+      }
+
+      if (restored.progressRatio == null && nextState.progressRatio != null) {
+        restored.progressRatio = nextState.progressRatio;
+      }
+
+      if (restored.progressPercent == null && nextState.progressPercent != null) {
+        restored.progressPercent = nextState.progressPercent;
+      }
+
+      if (restored.score == null && nextState.score != null) {
+        restored.score = nextState.score;
+      }
+    });
+
+    if (restored.progressPercent == null && restored.progressRatio != null) {
+      restored.progressPercent = restored.progressRatio * 100;
+    }
+
+    if (restored.progressRatio == null && restored.progressPercent != null) {
+      restored.progressRatio = restored.progressPercent / 100;
+    }
+
+    return restored;
+  }
+
+  function ensureSessionStarted(actionName) {
+    if (sessionFinished) {
+      runtimeLogger.warn(`Ignoring "${actionName}" because the session is already finished`, getState());
+      return false;
+    }
+
+    if (!sessionStarted || startTime == null) {
+      runtimeLogger.warn(`Ignoring "${actionName}" because the session has not been started yet`, getState());
+      return false;
+    }
+
+    return true;
+  }
+
+  return {
+    getState,
+    start() {
+      const {
+        scoreMin,
+        scoreMax,
+      } = getBasePayload();
+
+      if (!adapter || typeof adapter.start !== 'function') {
+        runtimeLogger.error('Session start failed', {
+          protocol: getProtocol(),
+          scoreMin,
+          scoreMax,
+        });
+        return false;
+      }
+
+      if (sessionFinished) {
+        runtimeLogger.warn('Ignoring start because the session is already finished', getState());
+        return false;
+      }
+
+      if (sessionStarted) {
+        runtimeLogger.warn('Ignoring start because the session is already started', getState());
+        return true;
+      }
+
+      const restored = restoreState();
+      startTime = restored.elapsedMs == null ? getNow() : getNow() - restored.elapsedMs;
+
+      const didStart = adapter.start(getBasePayload());
+      if (!didStart) {
+        runtimeLogger.error('Session start failed', {
+          protocol: getProtocol(),
+          scoreMin,
+          scoreMax,
+        });
+        return false;
+      }
+
+      sessionStarted = true;
+      sessionFinished = false;
+
+      if (restored.progressPercent != null) {
+        this.progress(restored.progressPercent);
+      }
+
+      if (restored.score != null) {
+        currentScore = normalizeScore(restored.score);
+        this.score(currentScore);
+      }
+
+      runtimeLogger.info('Session started', {
+        protocol: getProtocol(),
+        scoreMin,
+        scoreMax,
+        startTime,
+        restoredProgress: restored.progressRatio,
+        restoredScore: restored.score,
+      });
+      return true;
+    },
+    progress(value) {
+      const progressPercent = normalizeProgressPercent(value);
+      const progressRatio = progressPercent / 100;
+
+      if (!ensureSessionStarted('progress')) {
+        return false;
+      }
+
+      const payload = getBasePayload({
+        progressPercent,
+        progressRatio,
+      });
+      const didSync = adapter && typeof adapter.setProgress === 'function'
+        ? adapter.setProgress(payload)
+        : false;
+
+      runCompanionAdapters('setProgress', payload);
+
+      if (didSync) {
+        runtimeLogger.info('Progress synced', {
+          protocol: getProtocol(),
+          progressPercent,
+          progressRatio,
+          elapsedMs: payload.elapsedMs,
+        });
+      } else {
+        runtimeLogger.warn('Progress update completed with runtime warnings', {
+          protocol: getProtocol(),
+          progressPercent,
+          progressRatio,
+          elapsedMs: payload.elapsedMs,
+        });
+      }
+
+      return didSync;
+    },
+    score(value) {
+      currentScore = normalizeScore(value);
+
+      if (!ensureSessionStarted('score')) {
+        return false;
+      }
+
+      const payload = getBasePayload({
+        score: currentScore,
+      });
+      const didSync = adapter && typeof adapter.setScore === 'function'
+        ? adapter.setScore(payload)
+        : false;
+
+      runCompanionAdapters('setScore', payload);
+
+      if (didSync) {
+        runtimeLogger.info('Score synced', {
+          protocol: getProtocol(),
+          score: currentScore,
+          scoreMin: payload.scoreMin,
+          scoreMax: payload.scoreMax,
+          elapsedMs: payload.elapsedMs,
+        });
+      } else {
+        runtimeLogger.warn('Score update completed with runtime warnings', {
+          protocol: getProtocol(),
+          score: currentScore,
+          scoreMin: payload.scoreMin,
+          scoreMax: payload.scoreMax,
+          elapsedMs: payload.elapsedMs,
+        });
+      }
+
+      return didSync;
+    },
+    incScore(value) {
+      currentScore += normalizeScore(value);
+      return this.score(currentScore);
+    },
+    decScore(value) {
+      currentScore -= normalizeScore(value);
+      return this.score(currentScore);
+    },
+    incomplete() {
+      if (!ensureSessionStarted('incomplete')) {
+        return false;
+      }
+
+      const payload = getBasePayload();
+      const didSync = adapter && typeof adapter.markIncomplete === 'function'
+        ? adapter.markIncomplete(payload)
+        : false;
+
+      runCompanionAdapters('markIncomplete', payload);
+
+      if (didSync) {
+        runtimeLogger.info('Session marked incomplete', {
+          protocol: getProtocol(),
+          elapsedMs: payload.elapsedMs,
+        });
+      } else {
+        runtimeLogger.warn('Incomplete status update completed with runtime warnings', {
+          protocol: getProtocol(),
+          elapsedMs: payload.elapsedMs,
+        });
+      }
+
+      return didSync;
+    },
+    complete() {
+      if (!ensureSessionStarted('complete')) {
+        return false;
+      }
+
+      const payload = getBasePayload();
+      const didComplete = adapter && typeof adapter.complete === 'function'
+        ? adapter.complete(payload)
+        : false;
+
+      if (didComplete) {
+        runCompanionAdapters('complete', payload);
+        sessionStarted = false;
+        sessionFinished = true;
+        runtimeLogger.info('Session completed', {
+          protocol: getProtocol(),
+          elapsedMs: payload.elapsedMs,
+        });
+        return true;
+      }
+
+      runtimeLogger.warn('Session completion completed with runtime warnings', {
+        protocol: getProtocol(),
+        elapsedMs: payload.elapsedMs,
+      });
+      return false;
+    },
+    timedout() {
+      if (!ensureSessionStarted('timedout')) {
+        return false;
+      }
+
+      const payload = getBasePayload();
+      const didTimeout = adapter && typeof adapter.timeout === 'function'
+        ? adapter.timeout(payload)
+        : false;
+
+      if (didTimeout) {
+        runCompanionAdapters('timeout', payload);
+        sessionStarted = false;
+        sessionFinished = true;
+        runtimeLogger.warn('Session timed out', {
+          protocol: getProtocol(),
+          elapsedMs: payload.elapsedMs,
+        });
+        return true;
+      }
+
+      runtimeLogger.warn('Session timeout completed with runtime warnings', {
+        protocol: getProtocol(),
+        elapsedMs: payload.elapsedMs,
+      });
+      return false;
+    },
+  };
+}

--- a/src/runtime/tracker-core.mjs
+++ b/src/runtime/tracker-core.mjs
@@ -47,8 +47,10 @@ export function createTracker({
 
   let startTime = null;
   let currentScore = 0;
+  let sessionStarting = false;
   let sessionStarted = false;
   let sessionFinished = false;
+  let startPromise = null;
 
   function getProtocol() {
     return adapter && adapter.protocol ? adapter.protocol : null;
@@ -57,6 +59,7 @@ export function createTracker({
   function getState() {
     return {
       protocol: getProtocol(),
+      sessionStarting,
       sessionStarted,
       sessionFinished,
       startTime,
@@ -149,6 +152,20 @@ export function createTracker({
     return true;
   }
 
+  async function waitForPendingStart(actionName) {
+    if (!sessionStarting || !startPromise) {
+      return true;
+    }
+
+    const didStart = await startPromise;
+    if (!didStart) {
+      runtimeLogger.warn(`Ignoring "${actionName}" because the session failed to start`, getState());
+      return false;
+    }
+
+    return true;
+  }
+
   return {
     getState,
     async start() {
@@ -176,44 +193,71 @@ export function createTracker({
         return true;
       }
 
-      const restored = await restoreState();
-      startTime = restored.elapsedMs == null ? getNow() : getNow() - restored.elapsedMs;
-
-      const { ok: didStart } = normalizeActionResult(await adapter.start(getBasePayload()));
-      if (!didStart) {
-        runtimeLogger.error('Session start failed', {
-          protocol: getProtocol(),
-          scoreMin,
-          scoreMax,
-        });
-        return false;
+      if (sessionStarting && startPromise) {
+        return startPromise;
       }
 
-      sessionStarted = true;
-      sessionFinished = false;
+      sessionStarting = true;
+      const currentStartPromise = (async () => {
+        try {
+          const restored = await restoreState();
+          startTime = restored.elapsedMs == null ? getNow() : getNow() - restored.elapsedMs;
 
-      if (restored.progressPercent != null) {
-        await this.progress(restored.progressPercent);
-      }
+          const { ok: didStart } = normalizeActionResult(await adapter.start(getBasePayload()));
+          if (!didStart) {
+            sessionStarting = false;
+            startTime = null;
+            runtimeLogger.error('Session start failed', {
+              protocol: getProtocol(),
+              scoreMin,
+              scoreMax,
+            });
+            return false;
+          }
 
-      if (restored.score != null) {
-        currentScore = normalizeScore(restored.score);
-        await this.score(currentScore);
-      }
+          sessionStarting = false;
+          sessionStarted = true;
+          sessionFinished = false;
 
-      runtimeLogger.info('Session started', {
-        protocol: getProtocol(),
-        scoreMin,
-        scoreMax,
-        startTime,
-        restoredProgress: restored.progressRatio,
-        restoredScore: restored.score,
-      });
-      return true;
+          if (restored.progressPercent != null) {
+            await this.progress(restored.progressPercent);
+          }
+
+          if (restored.score != null) {
+            currentScore = normalizeScore(restored.score);
+            await this.score(currentScore);
+          }
+
+          runtimeLogger.info('Session started', {
+            protocol: getProtocol(),
+            scoreMin,
+            scoreMax,
+            startTime,
+            restoredProgress: restored.progressRatio,
+            restoredScore: restored.score,
+          });
+          return true;
+        } catch (error) {
+          sessionStarting = false;
+          startTime = null;
+          throw error;
+        } finally {
+          if (startPromise === currentStartPromise) {
+            startPromise = null;
+          }
+        }
+      })();
+
+      startPromise = currentStartPromise;
+      return currentStartPromise;
     },
     async progress(value) {
       const progressPercent = normalizeProgressPercent(value);
       const progressRatio = progressPercent / 100;
+
+      if (!(await waitForPendingStart('progress'))) {
+        return false;
+      }
 
       if (!ensureSessionStarted('progress')) {
         return false;
@@ -252,11 +296,15 @@ export function createTracker({
       return outcome.ok;
     },
     async score(value) {
-      currentScore = normalizeScore(value);
+      if (!(await waitForPendingStart('score'))) {
+        return false;
+      }
 
       if (!ensureSessionStarted('score')) {
         return false;
       }
+
+      currentScore = normalizeScore(value);
 
       const payload = getBasePayload({
         score: currentScore,
@@ -292,6 +340,10 @@ export function createTracker({
       return outcome.ok;
     },
     async incScore(value) {
+      if (!(await waitForPendingStart('incScore'))) {
+        return false;
+      }
+
       if (!ensureSessionStarted('incScore')) {
         return false;
       }
@@ -300,6 +352,10 @@ export function createTracker({
       return this.score(currentScore);
     },
     async decScore(value) {
+      if (!(await waitForPendingStart('decScore'))) {
+        return false;
+      }
+
       if (!ensureSessionStarted('decScore')) {
         return false;
       }
@@ -308,6 +364,10 @@ export function createTracker({
       return this.score(currentScore);
     },
     async incomplete() {
+      if (!(await waitForPendingStart('incomplete'))) {
+        return false;
+      }
+
       if (!ensureSessionStarted('incomplete')) {
         return false;
       }
@@ -338,6 +398,10 @@ export function createTracker({
       return outcome.ok;
     },
     async complete() {
+      if (!(await waitForPendingStart('complete'))) {
+        return false;
+      }
+
       if (!ensureSessionStarted('complete')) {
         return false;
       }
@@ -365,6 +429,10 @@ export function createTracker({
       return false;
     },
     async timedout() {
+      if (!(await waitForPendingStart('timedout'))) {
+        return false;
+      }
+
       if (!ensureSessionStarted('timedout')) {
         return false;
       }

--- a/src/runtime/tracker-core.mjs
+++ b/src/runtime/tracker-core.mjs
@@ -292,10 +292,18 @@ export function createTracker({
       return outcome.ok;
     },
     async incScore(value) {
+      if (!ensureSessionStarted('incScore')) {
+        return false;
+      }
+
       currentScore += normalizeScore(value);
       return this.score(currentScore);
     },
     async decScore(value) {
+      if (!ensureSessionStarted('decScore')) {
+        return false;
+      }
+
       currentScore -= normalizeScore(value);
       return this.score(currentScore);
     },

--- a/test/runtime/cmi5-adapter.test.mjs
+++ b/test/runtime/cmi5-adapter.test.mjs
@@ -53,6 +53,7 @@ function createJsonResponse(status, body) {
 
 function createFetchHarness({
   launchMode = 'Normal',
+  moveOn = 'Completed',
   masteryScore = 0.75,
   learnerPreferences = {
     languagePreference: 'en-US',
@@ -76,7 +77,7 @@ function createFetchHarness({
       },
     },
     launchMode,
-    moveOn: 'Completed',
+    moveOn,
     masteryScore,
   };
 
@@ -122,6 +123,10 @@ function createFetchHarness({
   };
 }
 
+function getCategoryIds(statement) {
+  return ((statement.context || {}).contextActivities || {}).category || [];
+}
+
 test('cmi5 start fetches token and launch documents before initialized', async () => {
   const harness = createFetchHarness();
   const adapter = createCmi5Adapter({
@@ -142,6 +147,9 @@ test('cmi5 start fetches token and launch documents before initialized', async (
   assert.equal(harness.statements[0].verb.id, 'http://adlnet.gov/expapi/verbs/initialized');
   assert.equal(harness.statements[0].context.registration, 'reg-123');
   assert.equal(harness.statements[0].object.id, 'https://example.com/activity/1');
+  assert.deepEqual(getCategoryIds(harness.statements[0]).map((item) => item.id), [
+    'https://w3id.org/xapi/cmi5/context/categories/cmi5',
+  ]);
 });
 
 test('cmi5 progress emits progressed statements and ignores 0 and 100', async () => {
@@ -179,8 +187,9 @@ test('cmi5 progress emits progressed statements and ignores 0 and 100', async ()
   );
 });
 
-test('cmi5 complete emits completed, passed, and terminated using cached score', async () => {
+test('cmi5 complete emits passed, completed, and terminated for CompletedAndPassed', async () => {
   const harness = createFetchHarness({
+    moveOn: 'CompletedAndPassed',
     masteryScore: 0.75,
   });
   const adapter = createCmi5Adapter({
@@ -216,13 +225,134 @@ test('cmi5 complete emits completed, passed, and terminated using cached score',
     elapsedMs: 10000,
   }), true);
   assert.equal(harness.statements.length, 4);
-  assert.equal(harness.statements[1].verb.id, 'http://adlnet.gov/expapi/verbs/completed');
-  assert.equal(harness.statements[1].result.completion, true);
-  assert.equal(harness.statements[2].verb.id, 'http://adlnet.gov/expapi/verbs/passed');
-  assert.equal(harness.statements[2].result.score.raw, 80);
-  assert.equal(harness.statements[2].result.score.scaled, 0.8);
-  assert.equal(harness.statements[2].result.success, true);
+  assert.equal(harness.statements[1].verb.id, 'http://adlnet.gov/expapi/verbs/passed');
+  assert.equal(harness.statements[1].result.score.raw, 80);
+  assert.equal(harness.statements[1].result.score.scaled, 0.8);
+  assert.equal(harness.statements[1].result.success, true);
+  assert.equal(harness.statements[2].verb.id, 'http://adlnet.gov/expapi/verbs/completed');
+  assert.equal(harness.statements[2].result.completion, true);
   assert.equal(harness.statements[3].verb.id, 'http://adlnet.gov/expapi/verbs/terminated');
+  assert.deepEqual(getCategoryIds(harness.statements[1]).map((item) => item.id), [
+    'https://w3id.org/xapi/cmi5/context/categories/cmi5',
+    'https://w3id.org/xapi/cmi5/context/categories/moveon',
+  ]);
+  assert.deepEqual(getCategoryIds(harness.statements[2]).map((item) => item.id), [
+    'https://w3id.org/xapi/cmi5/context/categories/cmi5',
+    'https://w3id.org/xapi/cmi5/context/categories/moveon',
+  ]);
+  assert.deepEqual(getCategoryIds(harness.statements[3]).map((item) => item.id), [
+    'https://w3id.org/xapi/cmi5/context/categories/cmi5',
+  ]);
+});
+
+test('cmi5 Passed moveOn emits failed and terminated without completed when learner fails', async () => {
+  const harness = createFetchHarness({
+    moveOn: 'Passed',
+    masteryScore: 0.75,
+  });
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:12.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+  await adapter.setScore({
+    score: 50,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 12000,
+  });
+
+  assert.equal(await adapter.complete({
+    currentScore: 50,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 12000,
+  }), true);
+  assert.deepEqual(harness.statements.map((statement) => statement.verb.id), [
+    'http://adlnet.gov/expapi/verbs/initialized',
+    'http://adlnet.gov/expapi/verbs/failed',
+    'http://adlnet.gov/expapi/verbs/terminated',
+  ]);
+});
+
+test('cmi5 Passed moveOn fails cleanly when success cannot be evaluated', async () => {
+  const harness = createFetchHarness({
+    moveOn: 'Passed',
+    masteryScore: null,
+  });
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:14.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+
+  assert.equal(await adapter.complete({
+    currentScore: 80,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 14000,
+  }), false);
+  assert.equal(harness.statements.length, 1);
+});
+
+test('cmi5 CompletedOrPassed moveOn keeps completion path minimal', async () => {
+  const harness = createFetchHarness({
+    moveOn: 'CompletedOrPassed',
+    masteryScore: 0.75,
+  });
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:16.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+  await adapter.setScore({
+    score: 80,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 16000,
+  });
+
+  assert.equal(await adapter.complete({
+    currentScore: 80,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 16000,
+  }), true);
+  assert.deepEqual(harness.statements.map((statement) => statement.verb.id), [
+    'http://adlnet.gov/expapi/verbs/initialized',
+    'http://adlnet.gov/expapi/verbs/completed',
+    'http://adlnet.gov/expapi/verbs/terminated',
+  ]);
 });
 
 test('cmi5 browse mode only sends initialized and terminated', async () => {

--- a/test/runtime/cmi5-adapter.test.mjs
+++ b/test/runtime/cmi5-adapter.test.mjs
@@ -7,6 +7,7 @@ import { createCmi5Adapter } from '../../src/runtime/adapters/cmi5.mjs';
 
 const ENDPOINT = 'https://lrs.example.com/xapi/';
 const FETCH_URL = 'https://lms.example.com/cmi5/fetch-token';
+const MASTERY_SCORE_EXTENSION_ID = 'https://w3id.org/xapi/cmi5/context/extensions/masteryscore';
 
 function createLaunchContext() {
   return {
@@ -229,6 +230,7 @@ test('cmi5 complete emits passed, completed, and terminated for CompletedAndPass
   assert.equal(harness.statements[1].result.score.raw, 80);
   assert.equal(harness.statements[1].result.score.scaled, 0.8);
   assert.equal(harness.statements[1].result.success, true);
+  assert.equal(harness.statements[1].context.extensions[MASTERY_SCORE_EXTENSION_ID], 0.75);
   assert.equal(harness.statements[2].verb.id, 'http://adlnet.gov/expapi/verbs/completed');
   assert.equal(harness.statements[2].result.completion, true);
   assert.equal(harness.statements[3].verb.id, 'http://adlnet.gov/expapi/verbs/terminated');
@@ -283,6 +285,7 @@ test('cmi5 Passed moveOn emits failed and terminated without completed when lear
     'http://adlnet.gov/expapi/verbs/failed',
     'http://adlnet.gov/expapi/verbs/terminated',
   ]);
+  assert.equal(harness.statements[1].context.extensions[MASTERY_SCORE_EXTENSION_ID], 0.75);
 });
 
 test('cmi5 Passed moveOn fails cleanly when success cannot be evaluated', async () => {

--- a/test/runtime/cmi5-adapter.test.mjs
+++ b/test/runtime/cmi5-adapter.test.mjs
@@ -1,0 +1,295 @@
+/* eslint-disable import/extensions, import/no-unresolved */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createCmi5Adapter } from '../../src/runtime/adapters/cmi5.mjs';
+
+const ENDPOINT = 'https://lrs.example.com/xapi/';
+const FETCH_URL = 'https://lms.example.com/cmi5/fetch-token';
+
+function createLaunchContext() {
+  return {
+    endpoint: ENDPOINT,
+    fetch: FETCH_URL,
+    registration: 'reg-123',
+    activityId: 'https://example.com/activity/1',
+    activityid: 'https://example.com/activity/1',
+    actor: JSON.stringify({
+      objectType: 'Agent',
+      account: {
+        homePage: 'https://lms.example.com',
+        name: 'learner-1',
+      },
+    }),
+    actorJson: {
+      objectType: 'Agent',
+      account: {
+        homePage: 'https://lms.example.com',
+        name: 'learner-1',
+      },
+    },
+  };
+}
+
+function createLogger() {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+}
+
+function createJsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function createFetchHarness({
+  launchMode = 'Normal',
+  masteryScore = 0.75,
+  learnerPreferences = {
+    languagePreference: 'en-US',
+    audioPreference: 'on',
+  },
+} = {}) {
+  const requests = [];
+  const statements = [];
+  const launchData = {
+    contextTemplate: {
+      contextActivities: {
+        grouping: [
+          {
+            id: 'https://example.com/publisher',
+            objectType: 'Activity',
+          },
+        ],
+      },
+      extensions: {
+        'https://w3id.org/xapi/cmi5/context/extensions/sessionid': 'session-123',
+      },
+    },
+    launchMode,
+    moveOn: 'Completed',
+    masteryScore,
+  };
+
+  async function fetchFn(url, options = {}) {
+    requests.push({
+      url,
+      method: options.method || 'GET',
+      headers: options.headers || {},
+      body: options.body || null,
+    });
+
+    if (url === FETCH_URL) {
+      return createJsonResponse(200, {
+        'auth-token': 'token-123',
+      });
+    }
+
+    if (url.startsWith(`${ENDPOINT}activities/state`)) {
+      return createJsonResponse(200, launchData);
+    }
+
+    if (url.startsWith(`${ENDPOINT}agents/profile`)) {
+      if (learnerPreferences == null) {
+        return createJsonResponse(404, {});
+      }
+
+      return createJsonResponse(200, learnerPreferences);
+    }
+
+    if (url === `${ENDPOINT}statements`) {
+      statements.push(JSON.parse(options.body));
+      return createJsonResponse(200, {});
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }
+
+  return {
+    fetchFn,
+    launchData,
+    requests,
+    statements,
+  };
+}
+
+test('cmi5 start fetches token and launch documents before initialized', async () => {
+  const harness = createFetchHarness();
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: () => 'statement-1',
+    getNow: () => new Date('2026-03-17T12:00:00.000Z').getTime(),
+  });
+
+  assert.equal(await adapter.start({ elapsedMs: 0 }), true);
+  assert.equal(harness.requests.length, 4);
+  assert.equal(harness.requests[0].method, 'POST');
+  assert.match(harness.requests[1].url, /activities\/state/);
+  assert.match(harness.requests[2].url, /agents\/profile/);
+  assert.equal(harness.requests[3].url, `${ENDPOINT}statements`);
+  assert.equal(harness.statements.length, 1);
+  assert.equal(harness.statements[0].verb.id, 'http://adlnet.gov/expapi/verbs/initialized');
+  assert.equal(harness.statements[0].context.registration, 'reg-123');
+  assert.equal(harness.statements[0].object.id, 'https://example.com/activity/1');
+});
+
+test('cmi5 progress emits progressed statements and ignores 0 and 100', async () => {
+  const harness = createFetchHarness();
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:05.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+
+  assert.equal(await adapter.setProgress({ progressPercent: 25, elapsedMs: 5000 }), true);
+  assert.deepEqual(await adapter.setProgress({ progressPercent: 0, elapsedMs: 5000 }), {
+    ok: true,
+    ignored: true,
+  });
+  assert.deepEqual(await adapter.setProgress({ progressPercent: 100, elapsedMs: 5000 }), {
+    ok: true,
+    ignored: true,
+  });
+  assert.equal(harness.statements.length, 2);
+  assert.equal(harness.statements[1].verb.id, 'http://adlnet.gov/expapi/verbs/progressed');
+  assert.equal(
+    harness.statements[1].result.extensions['https://w3id.org/xapi/cmi5/result/extensions/progress'],
+    25,
+  );
+});
+
+test('cmi5 complete emits completed, passed, and terminated using cached score', async () => {
+  const harness = createFetchHarness({
+    masteryScore: 0.75,
+  });
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:10.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+  assert.deepEqual(await adapter.setScore({
+    score: 80,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 10000,
+  }), {
+    ok: true,
+    ignored: true,
+  });
+  assert.equal(harness.statements.length, 1);
+
+  assert.equal(await adapter.complete({
+    currentScore: 80,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 10000,
+  }), true);
+  assert.equal(harness.statements.length, 4);
+  assert.equal(harness.statements[1].verb.id, 'http://adlnet.gov/expapi/verbs/completed');
+  assert.equal(harness.statements[1].result.completion, true);
+  assert.equal(harness.statements[2].verb.id, 'http://adlnet.gov/expapi/verbs/passed');
+  assert.equal(harness.statements[2].result.score.raw, 80);
+  assert.equal(harness.statements[2].result.score.scaled, 0.8);
+  assert.equal(harness.statements[2].result.success, true);
+  assert.equal(harness.statements[3].verb.id, 'http://adlnet.gov/expapi/verbs/terminated');
+});
+
+test('cmi5 browse mode only sends initialized and terminated', async () => {
+  const harness = createFetchHarness({
+    launchMode: 'Browse',
+  });
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:15.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+  assert.deepEqual(await adapter.setProgress({ progressPercent: 25, elapsedMs: 5000 }), {
+    ok: true,
+    ignored: true,
+  });
+  assert.deepEqual(await adapter.setScore({
+    score: 50,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 5000,
+  }), {
+    ok: true,
+    ignored: true,
+  });
+  assert.deepEqual(await adapter.markIncomplete({ elapsedMs: 5000 }), {
+    ok: true,
+    ignored: true,
+  });
+  assert.equal(await adapter.complete({
+    currentScore: 50,
+    scoreMin: 0,
+    scoreMax: 100,
+    elapsedMs: 5000,
+  }), true);
+  assert.equal(harness.statements.length, 2);
+  assert.equal(harness.statements[0].verb.id, 'http://adlnet.gov/expapi/verbs/initialized');
+  assert.equal(harness.statements[1].verb.id, 'http://adlnet.gov/expapi/verbs/terminated');
+});
+
+test('cmi5 timedout emits terminated only', async () => {
+  const harness = createFetchHarness();
+  const adapter = createCmi5Adapter({
+    launchContext: createLaunchContext(),
+    fetchFn: harness.fetchFn,
+    logger: createLogger(),
+    createStatementId: (() => {
+      let index = 0;
+      return () => {
+        index += 1;
+        return `statement-${index}`;
+      };
+    })(),
+    getNow: () => new Date('2026-03-17T12:00:20.000Z').getTime(),
+  });
+
+  await adapter.start({ elapsedMs: 0 });
+  assert.equal(await adapter.timeout({ elapsedMs: 20000 }), true);
+  assert.equal(harness.statements.length, 2);
+  assert.equal(harness.statements[1].verb.id, 'http://adlnet.gov/expapi/verbs/terminated');
+});

--- a/test/runtime/scorm-adapters.test.mjs
+++ b/test/runtime/scorm-adapters.test.mjs
@@ -1,0 +1,169 @@
+/* eslint-disable import/extensions, import/no-unresolved */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createLocalAdapter } from '../../src/runtime/adapters/local.mjs';
+import { createScorm12Adapter } from '../../src/runtime/adapters/scorm12.mjs';
+import { createScorm2004Adapter } from '../../src/runtime/adapters/scorm2004.mjs';
+
+function createLogger() {
+  return {
+    debug() {},
+    error() {},
+  };
+}
+
+function createScorm12Api() {
+  const calls = [];
+
+  return {
+    calls,
+    LMSInitialize(...args) {
+      calls.push(['LMSInitialize', args]);
+      return 'true';
+    },
+    LMSSetValue(...args) {
+      calls.push(['LMSSetValue', args]);
+      return 'true';
+    },
+    LMSCommit(...args) {
+      calls.push(['LMSCommit', args]);
+      return 'true';
+    },
+    LMSFinish(...args) {
+      calls.push(['LMSFinish', args]);
+      return 'true';
+    },
+    LMSGetLastError() {
+      return '0';
+    },
+    LMSGetErrorString() {
+      return 'No Error';
+    },
+    LMSGetDiagnostic() {
+      return 'Successful operation';
+    },
+  };
+}
+
+function createScorm2004Api() {
+  const calls = [];
+
+  return {
+    calls,
+    Initialize(...args) {
+      calls.push(['Initialize', args]);
+      return 'true';
+    },
+    SetValue(...args) {
+      calls.push(['SetValue', args]);
+      return 'true';
+    },
+    Commit(...args) {
+      calls.push(['Commit', args]);
+      return 'true';
+    },
+    Terminate(...args) {
+      calls.push(['Terminate', args]);
+      return 'true';
+    },
+    GetLastError() {
+      return '0';
+    },
+    GetErrorString() {
+      return 'No Error';
+    },
+    GetDiagnostic() {
+      return 'Successful operation';
+    },
+  };
+}
+
+function createStorage(seed = {}) {
+  const state = new Map(Object.entries(seed));
+
+  return {
+    getItem(key) {
+      return state.has(key) ? state.get(key) : null;
+    },
+    setItem(key, value) {
+      state.set(key, `${value}`);
+    },
+    dump() {
+      return Object.fromEntries(state.entries());
+    },
+  };
+}
+
+test('scorm12 adapter uses lesson_location for progress', () => {
+  const api = createScorm12Api();
+  const adapter = createScorm12Adapter({
+    api,
+    logger: createLogger(),
+  });
+
+  assert.equal(adapter.start({ scoreMin: 0, scoreMax: 100 }), true);
+  assert.equal(adapter.setProgress({ elapsedMs: 25000, progressPercent: 25 }), true);
+
+  assert.deepEqual(api.calls[1], ['LMSSetValue', ['cmi.core.lesson_status', 'incomplete']]);
+  assert.deepEqual(api.calls[5], ['LMSSetValue', ['cmi.core.session_time', '00:00:25']]);
+  assert.deepEqual(api.calls[6], ['LMSSetValue', ['cmi.core.lesson_location', '25']]);
+});
+
+test('scorm2004 adapter uses progress_measure for progress', () => {
+  const api = createScorm2004Api();
+  const adapter = createScorm2004Adapter({
+    api,
+    logger: createLogger(),
+  });
+
+  assert.equal(adapter.start({ scoreMin: 0, scoreMax: 100 }), true);
+  assert.equal(adapter.setProgress({ elapsedMs: 25000, progressRatio: 0.25 }), true);
+
+  assert.deepEqual(api.calls[1], ['SetValue', ['cmi.score.min', 0]]);
+  assert.deepEqual(api.calls[4], ['SetValue', ['cmi.session_time', 'PT00H00M25S']]);
+  assert.deepEqual(api.calls[5], ['SetValue', ['cmi.progress_measure', 0.25]]);
+});
+
+test('local adapter restores and syncs persisted state', () => {
+  const events = [];
+  const storage = createStorage({
+    unit_total_time: '3000',
+    unit_progress: '0.25',
+    unit_score: '42',
+  });
+  const adapter = createLocalAdapter({
+    enabled: true,
+    unitId: 'unit',
+    storage,
+    send(eventName, payload) {
+      events.push([eventName, payload]);
+    },
+  });
+
+  assert.deepEqual(adapter.restore(), {
+    elapsedMs: 3000,
+    progressPercent: 25,
+    progressRatio: 0.25,
+    score: 42,
+  });
+
+  assert.equal(adapter.setProgress({ elapsedMs: 5000, progressRatio: 0.5 }), true);
+  assert.equal(adapter.setScore({
+    elapsedMs: 5000,
+    score: 50,
+    scoreMin: 0,
+    scoreMax: 100,
+  }), true);
+
+  assert.deepEqual(storage.dump(), {
+    unit_progress: '0.5',
+    unit_score: '50',
+    unit_total_time: '5000',
+  });
+  assert.deepEqual(events, [
+    ['synchronize', [0.5, 'syncProgress', true]],
+    ['synchronize', [50, 'syncScore', true]],
+  ]);
+});

--- a/test/runtime/scorm-adapters.test.mjs
+++ b/test/runtime/scorm-adapters.test.mjs
@@ -167,3 +167,25 @@ test('local adapter restores and syncs persisted state', () => {
     ['synchronize', [50, 'syncScore', true]],
   ]);
 });
+
+test('local adapter supports a custom storage namespace', () => {
+  const storage = createStorage({
+    'unit:cmi5:reg-1_total_time': '3000',
+    'unit:cmi5:reg-1_progress': '0.25',
+    'unit:cmi5:reg-1_score': '42',
+    unit_total_time: '9999',
+  });
+  const adapter = createLocalAdapter({
+    enabled: true,
+    unitId: 'unit',
+    storageKeyPrefix: 'unit:cmi5:reg-1',
+    storage,
+  });
+
+  assert.deepEqual(adapter.restore(), {
+    elapsedMs: 3000,
+    progressPercent: 25,
+    progressRatio: 0.25,
+    score: 42,
+  });
+});

--- a/test/runtime/select-protocol.test.mjs
+++ b/test/runtime/select-protocol.test.mjs
@@ -1,0 +1,83 @@
+/* eslint-disable import/extensions, import/no-unresolved */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectProtocol } from '../../src/runtime/select-protocol.mjs';
+
+function buildCmi5QueryString(overrides = {}) {
+  const actor = {
+    name: 'Learner',
+    mbox: 'mailto:learner@example.com',
+    objectType: 'Agent',
+  };
+
+  const params = {
+    endpoint: 'https://lrs.example.com/xapi/',
+    fetch: 'https://example.com/cmi5/fetch',
+    registration: 'reg-123',
+    activityid: 'act-456',
+    actor: JSON.stringify(actor),
+    ...overrides,
+  };
+
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value != null) {
+      searchParams.set(key, value);
+    }
+  });
+
+  return {
+    queryString: `?${searchParams.toString()}`,
+    actor,
+  };
+}
+
+test('selectProtocol prefers cmi5 when all launch params exist', () => {
+  const { queryString, actor } = buildCmi5QueryString();
+
+  const result = selectProtocol({
+    queryString,
+    hasScorm2004: true,
+    hasScorm12: true,
+  });
+
+  assert.equal(result.protocol, 'cmi5');
+  assert.equal(result.context.cmi5.endpoint, 'https://lrs.example.com/xapi/');
+  assert.deepEqual(result.context.cmi5.actorJson, actor);
+});
+
+test('selectProtocol falls back to scorm2004 when cmi5 params are incomplete', () => {
+  const { queryString } = buildCmi5QueryString({
+    actor: null,
+  });
+
+  const result = selectProtocol({
+    queryString,
+    hasScorm2004: true,
+    hasScorm12: true,
+  });
+
+  assert.equal(result.protocol, 'scorm2004');
+});
+
+test('selectProtocol falls back to scorm12 when only scorm12 is available', () => {
+  const result = selectProtocol({
+    queryString: '',
+    hasScorm2004: false,
+    hasScorm12: true,
+  });
+
+  assert.equal(result.protocol, 'scorm12');
+});
+
+test('selectProtocol falls back to local when no scorm API is available', () => {
+  const result = selectProtocol({
+    queryString: '',
+    hasScorm2004: false,
+    hasScorm12: false,
+  });
+
+  assert.equal(result.protocol, 'local');
+});

--- a/test/runtime/select-protocol.test.mjs
+++ b/test/runtime/select-protocol.test.mjs
@@ -16,7 +16,7 @@ function buildCmi5QueryString(overrides = {}) {
     endpoint: 'https://lrs.example.com/xapi/',
     fetch: 'https://example.com/cmi5/fetch',
     registration: 'reg-123',
-    activityid: 'act-456',
+    activityId: 'act-456',
     actor: JSON.stringify(actor),
     ...overrides,
   };
@@ -45,7 +45,25 @@ test('selectProtocol prefers cmi5 when all launch params exist', () => {
 
   assert.equal(result.protocol, 'cmi5');
   assert.equal(result.context.cmi5.endpoint, 'https://lrs.example.com/xapi/');
+  assert.equal(result.context.cmi5.activityId, 'act-456');
   assert.deepEqual(result.context.cmi5.actorJson, actor);
+});
+
+test('selectProtocol still accepts legacy lowercase activityid launch params', () => {
+  const { queryString } = buildCmi5QueryString({
+    activityId: null,
+    activityid: 'act-legacy',
+  });
+
+  const result = selectProtocol({
+    queryString,
+    hasScorm2004: true,
+    hasScorm12: true,
+  });
+
+  assert.equal(result.protocol, 'cmi5');
+  assert.equal(result.context.cmi5.activityId, 'act-legacy');
+  assert.equal(result.context.cmi5.activityid, 'act-legacy');
 });
 
 test('selectProtocol falls back to scorm2004 when cmi5 params are incomplete', () => {

--- a/test/runtime/tracker-core.test.mjs
+++ b/test/runtime/tracker-core.test.mjs
@@ -55,6 +55,18 @@ function createAdapter(overrides = {}) {
   };
 }
 
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+}
+
 test('start initializes once', async () => {
   const adapter = createAdapter();
   const tracker = createTracker({
@@ -70,6 +82,38 @@ test('start initializes once', async () => {
   assert.equal(await tracker.start(), true);
   assert.equal(await tracker.start(), true);
   assert.equal(adapter.calls.start.length, 1);
+});
+
+test('progress waits for a pending start instead of being dropped', async () => {
+  const deferred = createDeferred();
+  const adapter = createAdapter({
+    start(payload) {
+      this.calls.start.push(payload);
+      return deferred.promise;
+    },
+  });
+  const tracker = createTracker({
+    adapter,
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => 1000,
+  });
+
+  const startPromise = tracker.start();
+  const progressPromise = tracker.progress(25);
+
+  assert.equal(adapter.calls.setProgress.length, 0);
+
+  deferred.resolve(true);
+
+  assert.equal(await startPromise, true);
+  assert.equal(await progressPromise, true);
+  assert.equal(adapter.calls.start.length, 1);
+  assert.equal(adapter.calls.setProgress.length, 1);
+  assert.equal(tracker.getState().sessionStarted, true);
 });
 
 test('progress before start is ignored', async () => {

--- a/test/runtime/tracker-core.test.mjs
+++ b/test/runtime/tracker-core.test.mjs
@@ -111,6 +111,21 @@ test('score after start delegates normalized values', async () => {
   assert.equal(adapter.calls.setScore[0].elapsedMs, 5000);
 });
 
+test('incScore and decScore before start do not mutate score state', async () => {
+  const tracker = createTracker({
+    adapter: createAdapter(),
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+  });
+
+  assert.equal(await tracker.incScore(5), false);
+  assert.equal(await tracker.decScore(2), false);
+  assert.equal(tracker.getState().currentScore, 0);
+});
+
 test('complete keeps session open when adapter complete fails', async () => {
   const adapter = createAdapter({
     complete(payload) {

--- a/test/runtime/tracker-core.test.mjs
+++ b/test/runtime/tracker-core.test.mjs
@@ -260,3 +260,42 @@ test('start replays restored state through companion adapters after primary star
   assert.equal(companionCalls.setProgress.length, 1);
   assert.equal(companionCalls.setScore.length, 1);
 });
+
+test('complete preserves restored companion score and elapsed time after a relaunch', async () => {
+  let now = 5000;
+  const completeCalls = [];
+  const tracker = createTracker({
+    adapter: createAdapter({
+      complete(payload) {
+        completeCalls.push(payload);
+        return true;
+      },
+    }),
+    companionAdapters: [{
+      restore() {
+        return {
+          elapsedMs: 3000,
+          score: 80,
+        };
+      },
+      setScore() {
+        return true;
+      },
+    }],
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => now,
+  });
+
+  assert.equal(await tracker.start(), true);
+
+  now = 7000;
+
+  assert.equal(await tracker.complete(), true);
+  assert.equal(completeCalls.length, 1);
+  assert.equal(completeCalls[0].currentScore, 80);
+  assert.equal(completeCalls[0].elapsedMs, 5000);
+});

--- a/test/runtime/tracker-core.test.mjs
+++ b/test/runtime/tracker-core.test.mjs
@@ -55,7 +55,7 @@ function createAdapter(overrides = {}) {
   };
 }
 
-test('start initializes once', () => {
+test('start initializes once', async () => {
   const adapter = createAdapter();
   const tracker = createTracker({
     adapter,
@@ -67,12 +67,12 @@ test('start initializes once', () => {
     getNow: () => 1000,
   });
 
-  assert.equal(tracker.start(), true);
-  assert.equal(tracker.start(), true);
+  assert.equal(await tracker.start(), true);
+  assert.equal(await tracker.start(), true);
   assert.equal(adapter.calls.start.length, 1);
 });
 
-test('progress before start is ignored', () => {
+test('progress before start is ignored', async () => {
   const adapter = createAdapter();
   const tracker = createTracker({
     adapter,
@@ -83,11 +83,11 @@ test('progress before start is ignored', () => {
     logger: createLogger(),
   });
 
-  assert.equal(tracker.progress(25), false);
+  assert.equal(await tracker.progress(25), false);
   assert.equal(adapter.calls.setProgress.length, 0);
 });
 
-test('score after start delegates normalized values', () => {
+test('score after start delegates normalized values', async () => {
   let now = 1000;
   const adapter = createAdapter();
   const tracker = createTracker({
@@ -100,10 +100,10 @@ test('score after start delegates normalized values', () => {
     getNow: () => now,
   });
 
-  tracker.start();
+  await tracker.start();
   now = 6000;
 
-  assert.equal(tracker.score(42), true);
+  assert.equal(await tracker.score(42), true);
   assert.equal(adapter.calls.setScore.length, 1);
   assert.equal(adapter.calls.setScore[0].score, 42);
   assert.equal(adapter.calls.setScore[0].scoreMin, 0);
@@ -111,7 +111,7 @@ test('score after start delegates normalized values', () => {
   assert.equal(adapter.calls.setScore[0].elapsedMs, 5000);
 });
 
-test('complete keeps session open when adapter complete fails', () => {
+test('complete keeps session open when adapter complete fails', async () => {
   const adapter = createAdapter({
     complete(payload) {
       this.calls.complete.push(payload);
@@ -128,14 +128,14 @@ test('complete keeps session open when adapter complete fails', () => {
     getNow: () => 1000,
   });
 
-  tracker.start();
+  await tracker.start();
 
-  assert.equal(tracker.complete(), false);
+  assert.equal(await tracker.complete(), false);
   assert.equal(tracker.getState().sessionFinished, false);
   assert.equal(tracker.getState().sessionStarted, true);
 });
 
-test('timedout keeps session open when adapter timeout fails', () => {
+test('timedout keeps session open when adapter timeout fails', async () => {
   const adapter = createAdapter({
     timeout(payload) {
       this.calls.timeout.push(payload);
@@ -152,9 +152,52 @@ test('timedout keeps session open when adapter timeout fails', () => {
     getNow: () => 1000,
   });
 
-  tracker.start();
+  await tracker.start();
 
-  assert.equal(tracker.timedout(), false);
+  assert.equal(await tracker.timedout(), false);
   assert.equal(tracker.getState().sessionFinished, false);
   assert.equal(tracker.getState().sessionStarted, true);
+});
+
+test('start replays restored state through companion adapters after primary start', async () => {
+  const adapter = createAdapter();
+  const companionCalls = {
+    restore: 0,
+    setProgress: [],
+    setScore: [],
+  };
+  const tracker = createTracker({
+    adapter,
+    companionAdapters: [{
+      restore() {
+        companionCalls.restore += 1;
+        return {
+          elapsedMs: 3000,
+          progressPercent: 25,
+          score: 12,
+        };
+      },
+      setProgress(payload) {
+        companionCalls.setProgress.push(payload);
+        return true;
+      },
+      setScore(payload) {
+        companionCalls.setScore.push(payload);
+        return true;
+      },
+    }],
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => 5000,
+  });
+
+  assert.equal(await tracker.start(), true);
+  assert.equal(companionCalls.restore, 1);
+  assert.equal(adapter.calls.setProgress.length, 1);
+  assert.equal(adapter.calls.setScore.length, 1);
+  assert.equal(companionCalls.setProgress.length, 1);
+  assert.equal(companionCalls.setScore.length, 1);
 });

--- a/test/runtime/tracker-core.test.mjs
+++ b/test/runtime/tracker-core.test.mjs
@@ -1,0 +1,160 @@
+/* eslint-disable import/extensions, import/no-unresolved */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createTracker } from '../../src/runtime/tracker-core.mjs';
+
+function createLogger() {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+}
+
+function createAdapter(overrides = {}) {
+  const calls = {
+    start: [],
+    setProgress: [],
+    setScore: [],
+    markIncomplete: [],
+    complete: [],
+    timeout: [],
+  };
+
+  return {
+    calls,
+    protocol: 'Test',
+    start(payload) {
+      calls.start.push(payload);
+      return true;
+    },
+    setProgress(payload) {
+      calls.setProgress.push(payload);
+      return true;
+    },
+    setScore(payload) {
+      calls.setScore.push(payload);
+      return true;
+    },
+    markIncomplete(payload) {
+      calls.markIncomplete.push(payload);
+      return true;
+    },
+    complete(payload) {
+      calls.complete.push(payload);
+      return true;
+    },
+    timeout(payload) {
+      calls.timeout.push(payload);
+      return true;
+    },
+    ...overrides,
+  };
+}
+
+test('start initializes once', () => {
+  const adapter = createAdapter();
+  const tracker = createTracker({
+    adapter,
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => 1000,
+  });
+
+  assert.equal(tracker.start(), true);
+  assert.equal(tracker.start(), true);
+  assert.equal(adapter.calls.start.length, 1);
+});
+
+test('progress before start is ignored', () => {
+  const adapter = createAdapter();
+  const tracker = createTracker({
+    adapter,
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+  });
+
+  assert.equal(tracker.progress(25), false);
+  assert.equal(adapter.calls.setProgress.length, 0);
+});
+
+test('score after start delegates normalized values', () => {
+  let now = 1000;
+  const adapter = createAdapter();
+  const tracker = createTracker({
+    adapter,
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => now,
+  });
+
+  tracker.start();
+  now = 6000;
+
+  assert.equal(tracker.score(42), true);
+  assert.equal(adapter.calls.setScore.length, 1);
+  assert.equal(adapter.calls.setScore[0].score, 42);
+  assert.equal(adapter.calls.setScore[0].scoreMin, 0);
+  assert.equal(adapter.calls.setScore[0].scoreMax, 100);
+  assert.equal(adapter.calls.setScore[0].elapsedMs, 5000);
+});
+
+test('complete keeps session open when adapter complete fails', () => {
+  const adapter = createAdapter({
+    complete(payload) {
+      this.calls.complete.push(payload);
+      return false;
+    },
+  });
+  const tracker = createTracker({
+    adapter,
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => 1000,
+  });
+
+  tracker.start();
+
+  assert.equal(tracker.complete(), false);
+  assert.equal(tracker.getState().sessionFinished, false);
+  assert.equal(tracker.getState().sessionStarted, true);
+});
+
+test('timedout keeps session open when adapter timeout fails', () => {
+  const adapter = createAdapter({
+    timeout(payload) {
+      this.calls.timeout.push(payload);
+      return false;
+    },
+  });
+  const tracker = createTracker({
+    adapter,
+    properties: {
+      'score.min': 0,
+      'score.max': 100,
+    },
+    logger: createLogger(),
+    getNow: () => 1000,
+  });
+
+  tracker.start();
+
+  assert.equal(tracker.timedout(), false);
+  assert.equal(tracker.getState().sessionFinished, false);
+  assert.equal(tracker.getState().sessionStarted, true);
+});


### PR DESCRIPTION
## Summary
- refactor the runtime behind protocol adapters with strict auto-detection `cmi5 > scorm2004 > scorm12 > local`
- add a cmi5 adapter while keeping the existing PandaSuite author-facing actions unchanged
- preserve SCORM behavior and harden resume/logging behavior, including same-registration cmi5 companion restore

## Test Plan
- `npm test`
- `npx eslint src/index.js src/logging.mjs src/runtime/**/*.mjs test/**/*.test.mjs`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

Related: beingenious/Panda.java#205